### PR TITLE
Update to AutoPas 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ Thumbs.db
 
 #cmake
 /build*
+/cmake-build*
 /CMakeCache.txt
 /CMakeFiles/
 /Makefile

--- a/cmake/Modules/Packages/USER-AUTOPAS.cmake
+++ b/cmake/Modules/Packages/USER-AUTOPAS.cmake
@@ -24,7 +24,9 @@ if (PKG_USER-AUTOPAS)
             autopas
             GIT_REPOSITORY ${autopasRepoPath}
             # GIT_TAG cacb3fa0e14b28bb8b50f10ec7fe16628bbb2582
-            GIT_TAG 435aca75cfb61b8284e84310cf19d6a5859f0b82
+#            GIT_TAG 435aca75cfb61b8284e84310cf19d6a5859f0b82
+#            GIT_TAG 829912490c798c2eff623e9da1f645ed8b97754e
+            GIT_TAG db49723d513f7c523c144e4d9c0d50dc91911a5e
     )
 
     option(AUTOPAS_BUILD_TESTS "" OFF)

--- a/cmake/Modules/Packages/USER-AUTOPAS.cmake
+++ b/cmake/Modules/Packages/USER-AUTOPAS.cmake
@@ -1,3 +1,5 @@
+option(PKG_USER-AUTOPAS "Enable AutoPas support" ON)
+
 if (PKG_USER-AUTOPAS)
 
     if (CMAKE_VERSION VERSION_LESS "3.16")

--- a/cmake/Modules/Packages/USER-AUTOPAS.cmake
+++ b/cmake/Modules/Packages/USER-AUTOPAS.cmake
@@ -19,14 +19,14 @@ if (PKG_USER-AUTOPAS)
         set(autopasRepoPath git@github.com:AutoPas/AutoPas.git)
     endif ()
 
+    # Final version of 2 Body AutoPas
+    set(AUTOPAS_TAG v2.0.0 CACHE STRING "AutoPas Git tag or commit id to use")
+
     # Download and install autopas
     FetchContent_Declare(
             autopas
             GIT_REPOSITORY ${autopasRepoPath}
-            # GIT_TAG cacb3fa0e14b28bb8b50f10ec7fe16628bbb2582
-#            GIT_TAG 435aca75cfb61b8284e84310cf19d6a5859f0b82
-#            GIT_TAG 829912490c798c2eff623e9da1f645ed8b97754e
-            GIT_TAG db49723d513f7c523c144e4d9c0d50dc91911a5e
+            GIT_TAG ${AUTOPAS_TAG}
     )
 
     option(AUTOPAS_BUILD_TESTS "" OFF)

--- a/cmake/Modules/Packages/USER-AUTOPAS.cmake
+++ b/cmake/Modules/Packages/USER-AUTOPAS.cmake
@@ -46,6 +46,8 @@ if (PKG_USER-AUTOPAS)
     FetchContent_MakeAvailable(autopas)
 
     list(APPEND LAMMPS_LINK_LIBS "autopas")
+    # Link detached library which contains the particle properties library
+    list(APPEND LAMMPS_LINK_LIBS "molecularDynamicsLibrary")
 
 
     ######### 2. AutoPas package settings #########

--- a/cmake/Modules/Packages/USER-AUTOPAS.cmake
+++ b/cmake/Modules/Packages/USER-AUTOPAS.cmake
@@ -24,7 +24,7 @@ if (PKG_USER-AUTOPAS)
             autopas
             GIT_REPOSITORY ${autopasRepoPath}
             # GIT_TAG cacb3fa0e14b28bb8b50f10ec7fe16628bbb2582
-            GIT_TAG ab14c135d5790de357dac56930827cfb791b4114
+            GIT_TAG 435aca75cfb61b8284e84310cf19d6a5859f0b82
     )
 
     option(AUTOPAS_BUILD_TESTS "" OFF)

--- a/cmake/Modules/Packages/USER-AUTOPAS.cmake
+++ b/cmake/Modules/Packages/USER-AUTOPAS.cmake
@@ -23,7 +23,8 @@ if (PKG_USER-AUTOPAS)
     FetchContent_Declare(
             autopas
             GIT_REPOSITORY ${autopasRepoPath}
-            GIT_TAG cacb3fa0e14b28bb8b50f10ec7fe16628bbb2582
+            # GIT_TAG cacb3fa0e14b28bb8b50f10ec7fe16628bbb2582
+            GIT_TAG ab14c135d5790de357dac56930827cfb791b4114
     )
 
     option(AUTOPAS_BUILD_TESTS "" OFF)

--- a/src/USER-AUTOPAS/atom_vec_atomic_autopas.cpp
+++ b/src/USER-AUTOPAS/atom_vec_atomic_autopas.cpp
@@ -449,7 +449,7 @@ AtomVecAtomicAutopas::data_atom(double *coord, imageint imagetmp,
 void AtomVecAtomicAutopas::pack_data(double **buf) {
 
 #pragma omp parallel default(none) shared(buf)
-  for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
     auto &x_{iter->getR()};
     auto idx{iter->getLocalID()};
     buf[idx][0] = ubuf(tag[idx]).d;

--- a/src/USER-AUTOPAS/autopas.cpp
+++ b/src/USER-AUTOPAS/autopas.cpp
@@ -362,12 +362,15 @@ AutoPasLMP::ParticleType *AutoPasLMP::particle_by_index(int idx) {
   }
 }
 
-void AutoPasLMP::update_autopas() {
+bool AutoPasLMP::update_autopas() {
   auto invalidParticles = _autopas->updateContainer();
+  if (!invalidParticles.empty()) {
+    _leavingParticles = std::move(invalidParticles);
+    _index_structure_valid = false;
+    return true;
+  }
 
-  _leavingParticles = std::move(invalidParticles);
-  _index_structure_valid = false;
-  return;
+  return false;
 }
 
 void AutoPasLMP::move_into() {

--- a/src/USER-AUTOPAS/autopas.cpp
+++ b/src/USER-AUTOPAS/autopas.cpp
@@ -466,13 +466,13 @@ template <bool halo> void AutoPasLMP::add_particle(const ParticleType &p) {
 #pragma clang diagnostic pop
 
 template <bool haloOnly>
-autopas::ParticleIteratorWrapper<AutoPasLMP::ParticleType, true>
+AutoPasLMP::AutoPasType::RegionIteratorT
 AutoPasLMP::particles_by_slab(int dim, double lo, double hi) const {
 
   std::array<double, 3> low{};
   std::array<double, 3> high{};
 
-  low.fill(-std::numeric_limits<double>::max());
+  low.fill(std::numeric_limits<double>::lowest());
   high.fill(std::numeric_limits<double>::max());
 
   low[dim] = lo;
@@ -505,7 +505,7 @@ bool AutoPasLMP::iterate_pairwise(AutoPasLMP::PairFunctorType *functor) {
   return _autopas->iteratePairwise(functor);
 }
 
-AutoPasLMP::AutoPasType::const_iterator_t
+AutoPasLMP::AutoPasType::ConstIteratorT
 AutoPasLMP::const_iterate_auto(int first, int last) {
   auto nlocal{atom->nlocal};
   if (last < nlocal) {
@@ -517,7 +517,7 @@ AutoPasLMP::const_iterate_auto(int first, int last) {
   }
 }
 
-AutoPasLMP::AutoPasType::iterator_t AutoPasLMP::iterate_auto(int first,
+AutoPasLMP::AutoPasType::IteratorT AutoPasLMP::iterate_auto(int first,
                                                              int last) {
   auto nlocal{atom->nlocal};
   if (last < nlocal) {
@@ -577,8 +577,8 @@ template void AutoPasLMP::add_particle<false>(const ParticleType &p);
 
 template void AutoPasLMP::add_particle<true>(const ParticleType &p);
 
-template autopas::ParticleIteratorWrapper<AutoPasLMP::ParticleType, true>
+template AutoPasLMP::AutoPasType::RegionIteratorT
 AutoPasLMP::particles_by_slab<true>(int dim, double lo, double hi) const;
 
-template autopas::ParticleIteratorWrapper<AutoPasLMP::ParticleType, true>
+template AutoPasLMP::AutoPasType::RegionIteratorT
 AutoPasLMP::particles_by_slab<false>(int dim, double lo, double hi) const;

--- a/src/USER-AUTOPAS/autopas.h
+++ b/src/USER-AUTOPAS/autopas.h
@@ -8,7 +8,7 @@
 
 #include <autopas/AutoPas.h>
 #include <autopas/cells/FullParticleCell.h>
-#include <autopas/molecularDynamics/ParticlePropertiesLibrary.h>
+#include <molecularDynamicsLibrary/ParticlePropertiesLibrary.h>
 
 #include "autopas_lj_functor.h"
 #include "autopas_lj_functor_avx.h"
@@ -240,8 +240,8 @@ private:
     autopas::AcquisitionFunctionOption acquisition_function = {
         autopas::AcquisitionFunctionOption::upperConfidenceBound};
 
-    autopas::TuningStrategyOption tuning_strategy{
-        autopas::TuningStrategyOption::fullSearch};
+    std::vector<autopas::TuningStrategyOption> tuning_strategies{};
+    std::string rule_filename{};
     autopas::SelectorStrategyOption selector_strategy{
         autopas::SelectorStrategyOption::fastestAbs};
 

--- a/src/USER-AUTOPAS/autopas.h
+++ b/src/USER-AUTOPAS/autopas.h
@@ -26,7 +26,7 @@ public:
   using ParticleCellType = autopas::FullParticleCell<ParticleType>;
   using AutoPasType = autopas::AutoPas<ParticleType>;
   using ParticlePropertiesLibraryType = ParticlePropertiesLibrary<FloatType, size_t>;
-  using PairFunctorType = LJFunctorLammps<ParticleType, /*applyShift*/ false, /*useMixing*/ false, /*useNewton3*/ autopas::FunctorN3Modes::Both, /*calculateGlobals*/ true>;
+  using PairFunctorType = LJFunctorLammpsAVX<ParticleType, /*applyShift*/ false, /*useMixing*/ false, /*useNewton3*/ autopas::FunctorN3Modes::Both, /*calculateGlobals*/ true>;
 
   /*
    * Flag used to differentiate when LAMMPS is build with and without

--- a/src/USER-AUTOPAS/autopas.h
+++ b/src/USER-AUTOPAS/autopas.h
@@ -95,7 +95,7 @@ public:
    * @return
    */
   template<bool haloOnly = false>
-  [[nodiscard]] autopas::ParticleIteratorWrapper<ParticleType, true>
+  [[nodiscard]] AutoPasLMP::AutoPasType::RegionIteratorT
   particles_by_slab(int dim, double lo, double hi) const;
 
   /**
@@ -104,7 +104,7 @@ public:
    * @return Particle iterator
    */
   template<autopas::IteratorBehavior::Value iterateBehavior>
-  [[nodiscard]] AutoPasLMP::AutoPasType::iterator_t iterate() {
+  [[nodiscard]] AutoPasLMP::AutoPasType::IteratorT iterate() {
     return _autopas->begin(iterateBehavior);
   }
 
@@ -114,7 +114,7 @@ public:
    * @return Const particle iterator
    */
   template<autopas::IteratorBehavior::Value iterateBehavior>
-  [[nodiscard]] AutoPasLMP::AutoPasType::const_iterator_t const_iterate() const {
+  [[nodiscard]] AutoPasLMP::AutoPasType::ConstIteratorT const_iterate() const {
     return _autopas->cbegin(iterateBehavior);
   }
 
@@ -126,7 +126,7 @@ public:
    * @param last  Upper local index
    * @return Particle iterator
    */
-  [[nodiscard]] AutoPasLMP::AutoPasType::const_iterator_t
+  [[nodiscard]] AutoPasLMP::AutoPasType::ConstIteratorT
   const_iterate_auto(int first, int last);
 
   /**
@@ -137,7 +137,7 @@ public:
    * @param last  Upper local index
    * @return Const particle iterator
    */
-  [[nodiscard]] AutoPasLMP::AutoPasType::iterator_t
+  [[nodiscard]] AutoPasLMP::AutoPasType::IteratorT
   iterate_auto(int first, int last);
 
 

--- a/src/USER-AUTOPAS/autopas.h
+++ b/src/USER-AUTOPAS/autopas.h
@@ -24,9 +24,9 @@ public:
   using FloatVecType = std::array<FloatType, 3>;
   using ParticleType = MoleculeLJLammps<FloatType>;
   using ParticleCellType = autopas::FullParticleCell<ParticleType>;
-  using AutoPasType = autopas::AutoPas<ParticleType, ParticleCellType>;
+  using AutoPasType = autopas::AutoPas<ParticleType>;
   using ParticlePropertiesLibraryType = ParticlePropertiesLibrary<FloatType, size_t>;
-  using PairFunctorType = LJFunctorLammps<ParticleType, ParticleCellType, /*applyShift*/ false, /*useMixing*/ false, /*useNewton3*/ autopas::FunctorN3Modes::Both, /*calculateGlobals*/ true>;
+  using PairFunctorType = LJFunctorLammps<ParticleType, /*applyShift*/ false, /*useMixing*/ false, /*useNewton3*/ autopas::FunctorN3Modes::Both, /*calculateGlobals*/ true>;
 
   /*
    * Flag used to differentiate when LAMMPS is build with and without
@@ -49,10 +49,8 @@ public:
 
   /**
    * Rebuild the AutoPas container and update the leaving particles with the ones returned by AutoPas.
-   * @param must_rebuild When false, let AutoPas decide if rebuild is necessary
-   * @return Was container rebuild?
    */
-  bool update_autopas(bool must_rebuild);
+  void update_autopas();
 
   /**
    * Get a particle by its global index / particle ID.
@@ -105,7 +103,7 @@ public:
    * @tparam iterateBehavior Local, ghost or both
    * @return Particle iterator
    */
-  template<autopas::IteratorBehavior iterateBehavior>
+  template<autopas::IteratorBehavior::Value iterateBehavior>
   [[nodiscard]] AutoPasLMP::AutoPasType::iterator_t iterate() {
     return _autopas->begin(iterateBehavior);
   }
@@ -115,7 +113,7 @@ public:
    * @tparam iterateBehavior Local, ghost or both
    * @return Const particle iterator
    */
-  template<autopas::IteratorBehavior iterateBehavior>
+  template<autopas::IteratorBehavior::Value iterateBehavior>
   [[nodiscard]] AutoPasLMP::AutoPasType::const_iterator_t const_iterate() const {
     return _autopas->cbegin(iterateBehavior);
   }

--- a/src/USER-AUTOPAS/autopas.h
+++ b/src/USER-AUTOPAS/autopas.h
@@ -26,7 +26,7 @@ public:
   using ParticleCellType = autopas::FullParticleCell<ParticleType>;
   using AutoPasType = autopas::AutoPas<ParticleType, ParticleCellType>;
   using ParticlePropertiesLibraryType = ParticlePropertiesLibrary<FloatType, size_t>;
-  using PairFunctorType = LJFunctorAVXLammps<ParticleType, ParticleCellType, /*applyShift*/ false, /*useMixing*/ false, /*useNewton3*/ autopas::FunctorN3Modes::Both, /*calculateGlobals*/ true>;
+  using PairFunctorType = LJFunctorLammps<ParticleType, ParticleCellType, /*applyShift*/ false, /*useMixing*/ false, /*useNewton3*/ autopas::FunctorN3Modes::Both, /*calculateGlobals*/ true>;
 
   /*
    * Flag used to differentiate when LAMMPS is build with and without

--- a/src/USER-AUTOPAS/autopas.h
+++ b/src/USER-AUTOPAS/autopas.h
@@ -50,7 +50,7 @@ public:
   /**
    * Rebuild the AutoPas container and update the leaving particles with the ones returned by AutoPas.
    */
-  void update_autopas();
+  bool update_autopas();
 
   /**
    * Get a particle by its global index / particle ID.

--- a/src/USER-AUTOPAS/autopas_lj_functor.h
+++ b/src/USER-AUTOPAS/autopas_lj_functor.h
@@ -503,6 +503,7 @@ namespace LAMMPS_NS {
                 fy1ptr[i] += fyacc;
                 fz1ptr[i] += fzacc;
             }
+
             if (calculateGlobals) {
                 const int threadnum = autopas_get_thread_num();
                 SoAFloatPrecision newton3Factor = 1.;

--- a/src/USER-AUTOPAS/autopas_lj_functor.h
+++ b/src/USER-AUTOPAS/autopas_lj_functor.h
@@ -3,1388 +3,1012 @@
 #include <array>
 #include <utility>
 
-#include "autopas/iterators/SingleCellIterator.h"
 #include "autopas/molecularDynamics/ParticlePropertiesLibrary.h"
 #include "autopas/pairwiseFunctors/Functor.h"
+#include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/AlignedAllocator.h"
 #include "autopas/utils/ArrayMath.h"
+#include "autopas/utils/ExceptionHandler.h"
+#include "autopas/utils/SoA.h"
+#include "autopas/utils/StaticBoolSelector.h"
 #include "autopas/utils/WrapOpenMP.h"
 #include "autopas/utils/inBox.h"
-#if defined(AUTOPAS_CUDA)
-#include "autopas/molecularDynamics/LJFunctorCuda.cuh"
-#include "autopas/molecularDynamics/LJFunctorCudaGlobals.cuh"
-#include "autopas/utils/CudaDeviceVector.h"
-#include "autopas/utils/CudaStreamHandler.h"
-#else
-#include "autopas/utils/ExceptionHandler.h"
-#endif
 
 namespace LAMMPS_NS {
 
 /**
- * A functor to handle lennard-jones interactions between two particles
- * (molecules).
+ * A functor to handle lennard-jones interactions between two particles (molecules).
+ * This functor assumes that duplicated calculations are always happening, which is characteristic for a Full-Shell
+ * scheme.
  * @tparam Particle The type of particle.
- * @tparam ParticleCell The type of particlecell.
  * @tparam applyShift Switch for the lj potential to be truncated shifted.
- * @tparam useMixing Switch for the functor to be used with multiple particle
- * types. If set to false, _epsilon and _sigma need to be set and the
- * constructor with PPL can be omitted.
- * @tparam useNewton3 Switch for the functor to support newton3 on, off or both.
- * See FunctorN3Modes for possible values.
- * @tparam calculateGlobals Defines whether the global values are to be
- * calculated (energy, virial).
- * @tparam relevantForTuning Whether or not the auto-tuner should consider this
- * functor.
+ * @tparam useMixing Switch for the functor to be used with multiple particle types.
+ * If set to false, _epsilon and _sigma need to be set and the constructor with PPL can be omitted.
+ * @tparam useNewton3 Switch for the functor to support newton3 on, off or both. See FunctorN3Modes for possible values.
+ * @tparam calculateGlobals Defines whether the global values are to be calculated (energy, virial).
+ * @tparam relevantForTuning Whether or not the auto-tuner should consider this functor.
  */
-template <class Particle, class ParticleCell, bool applyShift = false,
-          bool useMixing = false,
-          autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both,
-          bool calculateGlobals = false, bool relevantForTuning = true>
-class LJFunctorLammps
-    : public autopas::Functor<
-          Particle, ParticleCell, typename Particle::SoAArraysType,
-          LJFunctorLammps<Particle, ParticleCell, applyShift, useMixing,
-                          useNewton3, calculateGlobals, relevantForTuning>> {
+    template <class Particle, bool applyShift = false, bool useMixing = false,
+            autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both, bool calculateGlobals = false,
+            bool relevantForTuning = true>
+    class LJFunctorLammps
+            : public autopas::Functor<Particle,
+                    LJFunctorLammps<Particle, applyShift, useMixing, useNewton3, calculateGlobals, relevantForTuning>> {
+        /**
+         * Structure of the SoAs defined by the particle.
+         */
+        using SoAArraysType = typename Particle::SoAArraysType;
 
-  using SoAArraysType = typename Particle::SoAArraysType;
-  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
+        /**
+         * Precision of SoA entries.
+         */
+        using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
 
-  using interactingTypes_t = std::vector<std::vector<int>>;
+        using interactingTypes_t = std::vector<std::vector<int>>;
 
-public:
-  /**
-   * Deleted default constructor
-   */
-  LJFunctorLammps() = delete;
+    public:
+        /**
+         * Deleted default constructor
+         */
+        LJFunctorLammps() = delete;
 
-private:
-  /**
-   * Internal, actual constructor.
-   * @param cutoff
-   * @param duplicatedCalculation Defines whether duplicated calculations are
-   * happening across processes / over the simulation boundary. e.g. eightShell:
-   * false, fullShell: true.
-   * @param dummy unused, only there to make the signature different from the
-   * public constructor.
-   */
-  explicit LJFunctorLammps(double cutoff, interactingTypes_t interactingTypes,
-                           void * /*dummy*/)
-      : autopas::Functor<
-            Particle, ParticleCell, SoAArraysType,
-            LJFunctorLammps<Particle, ParticleCell, applyShift, useMixing,
-                            useNewton3, calculateGlobals, relevantForTuning>>(
-            cutoff),
-        _cutoffsquare{cutoff * cutoff}, _upotSum{0.}, _virialSum{0., 0., 0.},
-        _aosThreadData(), _postProcessed{false}, _interactingTypes{std::move(
-                                                     interactingTypes)} {
-    using namespace autopas;
-    if constexpr (calculateGlobals) {
-      _aosThreadData.resize(autopas_get_max_threads());
-    }
-  }
-
-public:
-  /**
-   * Constructor for Functor with mixing disabled. When using this functor it is
-   * necessary to call setParticleProperties() to set internal constants because
-   * it does not use a particle properties library.
-   *
-   * @note Only to be used with mixing == false.
-   *
-   * @param cutoff
-   * @param duplicatedCalculation Defines whether duplicated calculations are
-   * happening across processes / over the simulation boundary. e.g. eightShell:
-   * false, fullShell: true.
-   */
-  explicit LJFunctorLammps(double cutoff,
-                           const interactingTypes_t &interactingTypes)
-      : LJFunctorLammps(cutoff, interactingTypes, nullptr) {
-    static_assert(not useMixing,
-                  "Mixing without a ParticlePropertiesLibrary is not possible! "
-                  "Use a different constructor or set "
-                  "mixing to false.");
-  }
-
-  /**
-   * Constructor for Functor with mixing active. This functor takes a
-   * ParticlePropertiesLibrary to look up (mixed) properties like sigma, epsilon
-   * and shift.
-   * @param cutoff
-   * @param particlePropertiesLibrary
-   * @param duplicatedCalculation Defines whether duplicated calculations are
-   * happening across processes / over the simulation boundary. e.g. eightShell:
-   * false, fullShell: true.
-   */
-  explicit LJFunctorLammps(
-      double cutoff, const interactingTypes_t &interactingTypes,
-      ParticlePropertiesLibrary<double, size_t> &particlePropertiesLibrary)
-      : LJFunctorLammps(cutoff, interactingTypes, nullptr) {
-    static_assert(useMixing,
-                  "Not using Mixing but using a ParticlePropertiesLibrary is "
-                  "not allowed! Use a different constructor "
-                  "or set mixing to true.");
-    _PPLibrary = &particlePropertiesLibrary;
-  }
-
-  bool isRelevantForTuning() override { return relevantForTuning; }
-
-  bool allowsNewton3() override {
-    using namespace autopas;
-    return useNewton3 == FunctorN3Modes::Newton3Only or
-           useNewton3 == FunctorN3Modes::Both;
-  }
-
-  bool allowsNonNewton3() override {
-    using namespace autopas;
-    return useNewton3 == FunctorN3Modes::Newton3Off or
-           useNewton3 == FunctorN3Modes::Both;
-  }
-
-  bool isAppropriateClusterSize(
-      unsigned int clusterSize,
-      autopas::DataLayoutOption::Value dataLayout) const override {
-    using namespace autopas;
-    if (dataLayout == DataLayoutOption::cuda) {
-#if defined(AUTOPAS_CUDA)
-      return _cudawrapper.isAppropriateClusterSize(clusterSize);
-#endif
-      return false;
-    } else {
-      return dataLayout == DataLayoutOption::aos; // LJFunctor does not yet
-                                                  // support soa for clusters.
-      // The reason for this is that the owned state is not handled correctly,
-      // see #396.
-    }
-  }
-
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
-    if (not doesInteract(i.getTypeId(), j.getTypeId()) or i.isDummy() or j.isDummy())
-      return;
-    using namespace autopas;
-    auto sigmasquare = _sigmasquare;
-    auto epsilon24 = _epsilon24;
-    auto shift6 = _shift6;
-    if constexpr (useMixing) {
-      sigmasquare = _PPLibrary->mixingSigmaSquare(i.getTypeId(), j.getTypeId());
-      epsilon24 = _PPLibrary->mixing24Epsilon(i.getTypeId(), j.getTypeId());
-      if constexpr (applyShift) {
-        shift6 = _PPLibrary->mixingShift6(i.getTypeId(), j.getTypeId());
-      }
-    }
-    auto dr = utils::ArrayMath::sub(i.getR(), j.getR());
-    double dr2 = utils::ArrayMath::dot(dr, dr);
-
-    if (dr2 > _cutoffsquare)
-      return;
-
-    double invdr2 = 1. / dr2;
-    double lj6 = sigmasquare * invdr2;
-    lj6 = lj6 * lj6 * lj6;
-    double lj12 = lj6 * lj6;
-    double lj12m6 = lj12 - lj6;
-    double fac = epsilon24 * (lj12 + lj12m6) * invdr2;
-    auto f = utils::ArrayMath::mulScalar(dr, fac);
-    i.addF(f);
-    if (newton3) {
-      // only if we use newton 3 here, we want to
-      j.subF(f);
-    }
-    if (calculateGlobals) {
-      std::array<double, 6> dr_virial = {dr[0], dr[1], dr[2],
-                                         dr[0], dr[0], dr[1]};
-      std::array<double, 6> f_virial = {f[0], f[1], f[2], f[1], f[2], f[2]};
-      auto virial = utils::ArrayMath::mul(dr_virial, f_virial);
-      double upot = epsilon24 * lj12m6 + shift6;
-
-      const int threadnum = autopas_get_thread_num();
-      // for non-newton3 the division is in the post-processing step.
-      if (newton3) {
-        upot *= 0.5;
-        virial = utils::ArrayMath::mulScalar(virial, (double)0.5);
-      }
-      if (i.isOwned()) {
-        _aosThreadData[threadnum].upotSum += upot;
-        _aosThreadData[threadnum].virialSum =
-            utils::ArrayMath::add(_aosThreadData[threadnum].virialSum, virial);
-      }
-      // for non-newton3 the second particle will be considered in a separate
-      // calculation
-      if (newton3 and j.isOwned()) {
-        _aosThreadData[threadnum].upotSum += upot;
-        _aosThreadData[threadnum].virialSum =
-            utils::ArrayMath::add(_aosThreadData[threadnum].virialSum, virial);
-      }
-    }
-  }
-
-  /**
-   * @copydoc Functor::SoAFunctorSingle(SoAView<SoAArraysType> soa, bool
-   * newton3, bool cellWiseOwnedState) This functor ignores will use a newton3
-   * like traversing of the soa, however, it still needs to know about newton3
-   * to use it correctly for the global values.
-   */
-  void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa,
-                        bool newton3) override {
-    using namespace autopas;
-    if (soa.getNumParticles() == 0)
-      return;
-
-    const auto *const __restrict__ xptr =
-        soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict__ yptr =
-        soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict__ zptr =
-        soa.template begin<Particle::AttributeNames::posZ>();
-    const auto *const __restrict__ ownedStatePtr =
-        soa.template begin<Particle::AttributeNames::ownershipState>();
-
-    SoAFloatPrecision *const __restrict__ fxptr =
-        soa.template begin<Particle::AttributeNames::forceX>();
-    SoAFloatPrecision *const __restrict__ fyptr =
-        soa.template begin<Particle::AttributeNames::forceY>();
-    SoAFloatPrecision *const __restrict__ fzptr =
-        soa.template begin<Particle::AttributeNames::forceZ>();
-
-    [[maybe_unused]] auto *const __restrict__ typeptr =
-        soa.template begin<Particle::AttributeNames::typeId>();
-    // the local redeclaration of the following values helps the
-    // SoAFloatPrecision-generation of various compilers.
-    const SoAFloatPrecision cutoffsquare = _cutoffsquare;
-
-    SoAFloatPrecision upotSum = 0.;
-    SoAFloatPrecision virialSumXX = 0.;
-    SoAFloatPrecision virialSumYY = 0.;
-    SoAFloatPrecision virialSumZZ = 0.;
-    SoAFloatPrecision virialSumXY = 0.;
-    SoAFloatPrecision virialSumXZ = 0.;
-    SoAFloatPrecision virialSumYZ = 0.;
-
-    std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>>
-        sigmaSquares;
-    std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>>
-        epsilon24s;
-    std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>> shift6s;
-    if constexpr (useMixing) {
-      // Preload all sigma and epsilons for next vectorized region.
-      // Not preloading and directly using the values, will produce worse
-      // results.
-      sigmaSquares.resize(soa.getNumParticles());
-      epsilon24s.resize(soa.getNumParticles());
-      // if no mixing or mixing but no shift shift6 is constant therefore we do
-      // not need this vector.
-      if constexpr (applyShift) {
-        shift6s.resize(soa.getNumParticles());
-      }
-    }
-
-    for (unsigned int i = 0; i < soa.getNumParticles(); ++i) {
-      const auto ownedStateI = ownedStatePtr[i];
-      if (ownedStateI == OwnershipState::dummy) {
-        continue;
-      }
-
-      SoAFloatPrecision fxacc = 0.;
-      SoAFloatPrecision fyacc = 0.;
-      SoAFloatPrecision fzacc = 0.;
-
-      if constexpr (useMixing) {
-        for (unsigned int j = 0; j < soa.getNumParticles(); ++j) {
-          auto mixingData = _PPLibrary->getMixingData(typeptr[i], typeptr[j]);
-          sigmaSquares[j] = mixingData.sigmaSquare;
-          epsilon24s[j] = mixingData.epsilon24;
-          if constexpr (applyShift) {
-            shift6s[j] = mixingData.shift6;
-          }
+    private:
+        /**
+         * Internal, actual constructor.
+         * @param cutoff
+         * @note param dummy is unused, only there to make the signature different from the public constructor.
+         */
+        explicit LJFunctorLammps(double cutoff, interactingTypes_t interactingTypes, void * /*dummy*/)
+                : autopas::Functor<Particle, LJFunctorLammps<Particle, applyShift, useMixing, useNewton3, calculateGlobals, relevantForTuning>>(
+                cutoff),
+                  _cutoffsquare{cutoff * cutoff},
+                  _upotSum{0.},
+                  _virialSum{0., 0., 0., 0., 0., 0.},
+                  _aosThreadData(),
+                  _postProcessed{false},
+                  _interactingTypes{std::move(interactingTypes)} {
+            using namespace autopas;
+            if constexpr (calculateGlobals) {
+                _aosThreadData.resize(autopas_get_max_threads());
+            }
         }
-      }
+
+    public:
+        /**
+         * Constructor for Functor with mixing disabled. When using this functor it is necessary to call
+         * setParticleProperties() to set internal constants because it does not use a particle properties library.
+         *
+         * @note Only to be used with mixing == false.
+         *
+         * @param cutoff
+         */
+        explicit LJFunctorLammps(double cutoff, const interactingTypes_t& interactingTypes) : LJFunctorLammps(cutoff, interactingTypes, nullptr) {
+            static_assert(not useMixing,
+                          "Mixing without a ParticlePropertiesLibrary is not possible! Use a different constructor or set "
+                          "mixing to false.");
+        }
+
+        /**
+         * Constructor for Functor with mixing active. This functor takes a ParticlePropertiesLibrary to look up (mixed)
+         * properties like sigma, epsilon and shift.
+         * @param cutoff
+         * @param particlePropertiesLibrary
+         */
+        explicit LJFunctorLammps(double cutoff, const interactingTypes_t& interactingTypes, ParticlePropertiesLibrary<double, size_t> &particlePropertiesLibrary)
+                : LJFunctorLammps(cutoff, interactingTypes, nullptr) {
+            static_assert(useMixing,
+                          "Not using Mixing but using a ParticlePropertiesLibrary is not allowed! Use a different constructor "
+                          "or set mixing to true.");
+            _PPLibrary = &particlePropertiesLibrary;
+        }
+
+        bool isRelevantForTuning() final { return relevantForTuning; }
+
+        bool allowsNewton3() final { return useNewton3 == autopas::FunctorN3Modes::Newton3Only or useNewton3 == autopas::FunctorN3Modes::Both; }
+
+        bool allowsNonNewton3() final {
+            return useNewton3 == autopas::FunctorN3Modes::Newton3Off or useNewton3 == autopas::FunctorN3Modes::Both;
+        }
+
+        void AoSFunctor(Particle &i, Particle &j, bool newton3) final {
+            if(not doesInteract(i.getTypeId(), j.getTypeId()) or i.isDummy() or j.isDummy()) return;
+            using namespace autopas;
+            if (i.isDummy() or j.isDummy()) {
+                return;
+            }
+            auto sigmasquare = _sigmasquare;
+            auto epsilon24 = _epsilon24;
+            auto shift6 = _shift6;
+            if constexpr (useMixing) {
+                sigmasquare = _PPLibrary->mixingSigmaSquare(i.getTypeId(), j.getTypeId());
+                epsilon24 = _PPLibrary->mixing24Epsilon(i.getTypeId(), j.getTypeId());
+                if constexpr (applyShift) {
+                    shift6 = _PPLibrary->mixingShift6(i.getTypeId(), j.getTypeId());
+                }
+            }
+            auto dr = utils::ArrayMath::sub(i.getR(), j.getR());
+            double dr2 = utils::ArrayMath::dot(dr, dr);
+
+            if (dr2 > _cutoffsquare) {
+                return;
+            }
+
+            double invdr2 = 1. / dr2;
+            double lj6 = sigmasquare * invdr2;
+            lj6 = lj6 * lj6 * lj6;
+            double lj12 = lj6 * lj6;
+            double lj12m6 = lj12 - lj6;
+            double fac = epsilon24 * (lj12 + lj12m6) * invdr2;
+            auto f = utils::ArrayMath::mulScalar(dr, fac);
+            i.addF(f);
+            if (newton3) {
+                // only if we use newton 3 here, we want to
+                j.subF(f);
+            }
+            if (calculateGlobals) {
+                std::array<double, 6> dr_virial = {dr[0], dr[1], dr[2], dr[0], dr[0], dr[1]};
+                std::array<double, 6> f_virial = {f[0], f[1], f[2], f[1], f[2], f[2]};
+                auto virial = utils::ArrayMath::mul(dr_virial, f_virial);
+                double upot = epsilon24 * lj12m6 + shift6;
+
+                const int threadnum = autopas_get_thread_num();
+                // for non-newton3 the division is in the post-processing step.
+                if (newton3) {
+                    upot *= 0.5;
+                    virial = utils::ArrayMath::mulScalar(virial, (double)0.5);
+                }
+                if (i.isOwned()) {
+                    _aosThreadData[threadnum].upotSum += upot;
+                    _aosThreadData[threadnum].virialSum = utils::ArrayMath::add(_aosThreadData[threadnum].virialSum, virial);
+                }
+                // for non-newton3 the second particle will be considered in a separate calculation
+                if (newton3 and j.isOwned()) {
+                    _aosThreadData[threadnum].upotSum += upot;
+                    _aosThreadData[threadnum].virialSum = utils::ArrayMath::add(_aosThreadData[threadnum].virialSum, virial);
+                }
+            }
+        }
+
+        /**
+         * @copydoc Functor::SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3)
+         * This functor ignores will use a newton3 like traversing of the soa, however, it still needs to know about newton3
+         * to use it correctly for the global values.
+         */
+        void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa, bool newton3) final {
+            using namespace autopas;
+            if (soa.getNumberOfParticles() == 0) return;
+
+            const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+            const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+            const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
+            const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+
+            SoAFloatPrecision *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
+            SoAFloatPrecision *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
+            SoAFloatPrecision *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+
+            [[maybe_unused]] auto *const __restrict typeptr = soa.template begin<Particle::AttributeNames::typeId>();
+            // the local redeclaration of the following values helps the SoAFloatPrecision-generation of various compilers.
+            const SoAFloatPrecision cutoffsquare = _cutoffsquare;
+
+            SoAFloatPrecision upotSum = 0.;
+            SoAFloatPrecision virialSumXX = 0.;
+            SoAFloatPrecision virialSumYY = 0.;
+            SoAFloatPrecision virialSumZZ = 0.;
+            SoAFloatPrecision virialSumXY = 0.;
+            SoAFloatPrecision virialSumXZ = 0.;
+            SoAFloatPrecision virialSumYZ = 0.;
+            
+
+            std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>> sigmaSquares;
+            std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>> epsilon24s;
+            std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>> shift6s;
+            if constexpr (useMixing) {
+                // Preload all sigma and epsilons for next vectorized region.
+                // Not preloading and directly using the values, will produce worse results.
+                sigmaSquares.resize(soa.getNumberOfParticles());
+                epsilon24s.resize(soa.getNumberOfParticles());
+                // if no mixing or mixing but no shift shift6 is constant therefore we do not need this vector.
+                if constexpr (applyShift) {
+                    shift6s.resize(soa.getNumberOfParticles());
+                }
+            }
+
+            const SoAFloatPrecision const_shift6 = _shift6;
+            const SoAFloatPrecision const_sigmasquare = _sigmasquare;
+            const SoAFloatPrecision const_epsilon24 = _epsilon24;
+
+            for (unsigned int i = 0; i < soa.getNumberOfParticles(); ++i) {
+                const auto ownedStateI = ownedStatePtr[i];
+                if (ownedStateI == OwnershipState::dummy) {
+                    continue;
+                }
+
+                SoAFloatPrecision fxacc = 0.;
+                SoAFloatPrecision fyacc = 0.;
+                SoAFloatPrecision fzacc = 0.;
+
+                if constexpr (useMixing) {
+                    for (unsigned int j = 0; j < soa.getNumberOfParticles(); ++j) {
+                        auto mixingData = _PPLibrary->getMixingData(typeptr[i], typeptr[j]);
+                        sigmaSquares[j] = mixingData.sigmaSquare;
+                        epsilon24s[j] = mixingData.epsilon24;
+                        if constexpr (applyShift) {
+                            shift6s[j] = mixingData.shift6;
+                        }
+                    }
+                }
 
 // icpc vectorizes this.
 // g++ only with -ffast-math or -funsafe-math-optimizations
 #pragma omp simd reduction(+ : fxacc, fyacc, fzacc, upotSum, virialSumXX, virialSumYY, virialSumZZ, virialSumXY, virialSumXZ, virialSumYZ)
-      for (unsigned int j = i + 1; j < soa.getNumParticles(); ++j) {
-        if (!doesInteract(typeptr[i], typeptr[j]))
-          continue;
+                for (unsigned int j = i + 1; j < soa.getNumberOfParticles(); ++j) {
+                    if(!doesInteract(typeptr[i], typeptr[j])) continue;
+                    SoAFloatPrecision shift6 = const_shift6;
+                    SoAFloatPrecision sigmasquare = const_sigmasquare;
+                    SoAFloatPrecision epsilon24 = const_epsilon24;
+                    if constexpr (useMixing) {
+                        sigmasquare = sigmaSquares[j];
+                        epsilon24 = epsilon24s[j];
+                        if constexpr (applyShift) {
+                            shift6 = shift6s[j];
+                        }
+                    }
 
-        SoAFloatPrecision shift6;
-        SoAFloatPrecision sigmasquare;
-        SoAFloatPrecision epsilon24;
-        if constexpr (useMixing) {
-          sigmasquare = sigmaSquares[j];
-          epsilon24 = epsilon24s[j];
-          if constexpr (applyShift) {
-            shift6 = shift6s[j];
-          }
-        } else {
-          shift6 = _shift6;
-          sigmasquare = _sigmasquare;
-          epsilon24 = _epsilon24;
+                    const auto ownedStateJ = ownedStatePtr[j];
+
+                    const SoAFloatPrecision drx = xptr[i] - xptr[j];
+                    const SoAFloatPrecision dry = yptr[i] - yptr[j];
+                    const SoAFloatPrecision drz = zptr[i] - zptr[j];
+
+                    const SoAFloatPrecision drx2 = drx * drx;
+                    const SoAFloatPrecision dry2 = dry * dry;
+                    const SoAFloatPrecision drz2 = drz * drz;
+
+                    const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
+
+                    // Mask away if distance is too large or any particle is a dummy.
+                    // Particle ownedStateI was already checked previously.
+                    const bool mask = dr2 <= cutoffsquare and ownedStateJ != OwnershipState::dummy;
+
+                    const SoAFloatPrecision invdr2 = 1. / dr2;
+                    const SoAFloatPrecision lj2 = sigmasquare * invdr2;
+                    const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
+                    const SoAFloatPrecision lj12 = lj6 * lj6;
+                    const SoAFloatPrecision lj12m6 = lj12 - lj6;
+                    const SoAFloatPrecision fac = mask ? epsilon24 * (lj12 + lj12m6) * invdr2 : 0.;
+
+                    const SoAFloatPrecision fx = drx * fac;
+                    const SoAFloatPrecision fy = dry * fac;
+                    const SoAFloatPrecision fz = drz * fac;
+
+                    fxacc += fx;
+                    fyacc += fy;
+                    fzacc += fz;
+
+                    // newton 3
+                    fxptr[j] -= fx;
+                    fyptr[j] -= fy;
+                    fzptr[j] -= fz;
+
+                    if (calculateGlobals) {
+                        const SoAFloatPrecision virialxx = drx * fx;
+                        const SoAFloatPrecision virialyy = dry * fy;
+                        const SoAFloatPrecision virialzz = drz * fz;
+                        const SoAFloatPrecision virialxy = drx * fy;
+                        const SoAFloatPrecision virialxz = drx * fz;
+                        const SoAFloatPrecision virialyz = dry * fz;
+                        const SoAFloatPrecision upot = mask ? (epsilon24 * lj12m6 + shift6) : 0.;
+
+                        // In this function, all pairs are only traversed once (newton3-scheme!).
+                        // In this case, the calculations are later divided by two!
+                        SoAFloatPrecision energyFactor =
+                                (ownedStateI == OwnershipState::owned ? 1. : 0.) + (ownedStateJ == OwnershipState::owned ? 1. : 0.);
+                        upotSum += upot * energyFactor;
+                        virialSumXX += virialxx * energyFactor;
+                        virialSumYY += virialyy * energyFactor;
+                        virialSumZZ += virialzz * energyFactor;
+                        virialSumXY += virialxy * energyFactor;
+                        virialSumXZ += virialxz * energyFactor;
+                        virialSumYZ += virialyz * energyFactor;
+                    }
+                }
+
+                fxptr[i] += fxacc;
+                fyptr[i] += fyacc;
+                fzptr[i] += fzacc;
+            }
+            if (calculateGlobals) {
+                const int threadnum = autopas_get_thread_num();
+                double factor = 1.;
+                // we assume newton3 to be enabled in this function call, thus we multiply by two if the value of newton3 is
+                // false, since for newton3 disabled we divide by two later on.
+                factor *= newton3 ? .5 : 1.;
+                _aosThreadData[threadnum].upotSum += upotSum * factor;
+                _aosThreadData[threadnum].virialSum[0] += virialSumXX * factor;
+                _aosThreadData[threadnum].virialSum[1] += virialSumYY * factor;
+                _aosThreadData[threadnum].virialSum[2] += virialSumZZ * factor;
+                _aosThreadData[threadnum].virialSum[3] += virialSumXY * factor;
+                _aosThreadData[threadnum].virialSum[4] += virialSumXZ * factor;
+                _aosThreadData[threadnum].virialSum[5] += virialSumYZ * factor;
+            }
         }
 
-        const auto ownedStateJ = ownedStatePtr[j];
-
-        const SoAFloatPrecision drx = xptr[i] - xptr[j];
-        const SoAFloatPrecision dry = yptr[i] - yptr[j];
-        const SoAFloatPrecision drz = zptr[i] - zptr[j];
-
-        const SoAFloatPrecision drx2 = drx * drx;
-        const SoAFloatPrecision dry2 = dry * dry;
-        const SoAFloatPrecision drz2 = drz * drz;
-
-        const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
-
-        // Mask away if distance is too large or any particle is a dummy.
-        // Particle ownedStateI was already checked previously.
-        const bool mask =
-            dr2 <= cutoffsquare and ownedStateJ != OwnershipState::dummy;
-
-        const SoAFloatPrecision invdr2 = 1. / dr2;
-        const SoAFloatPrecision lj2 = sigmasquare * invdr2;
-        const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
-        const SoAFloatPrecision lj12 = lj6 * lj6;
-        const SoAFloatPrecision lj12m6 = lj12 - lj6;
-        const SoAFloatPrecision fac =
-            mask ? epsilon24 * (lj12 + lj12m6) * invdr2 : 0.;
-
-        const SoAFloatPrecision fx = drx * fac;
-        const SoAFloatPrecision fy = dry * fac;
-        const SoAFloatPrecision fz = drz * fac;
-
-        fxacc += fx;
-        fyacc += fy;
-        fzacc += fz;
-
-        // newton 3
-        fxptr[j] -= fx;
-        fyptr[j] -= fy;
-        fzptr[j] -= fz;
-
-        if (calculateGlobals) {
-          const SoAFloatPrecision virialxx = drx * fx;
-          const SoAFloatPrecision virialyy = dry * fy;
-          const SoAFloatPrecision virialzz = drz * fz;
-          const SoAFloatPrecision virialxy = drx * fy;
-          const SoAFloatPrecision virialxz = drx * fz;
-          const SoAFloatPrecision virialyz = dry * fz;
-          const SoAFloatPrecision upot = (epsilon24 * lj12m6 + shift6) * mask;
-
-          // In this function, all pairs are only traversed once
-          // (newton3-scheme!). In this case, the calculations are later divided
-          // by two!
-          SoAFloatPrecision energyFactor =
-              (ownedStateI == OwnershipState::owned ? 1. : 0.) +
-              (ownedStateJ == OwnershipState::owned ? 1. : 0.);
-          upotSum += upot;
-          virialSumXX += virialxx;
-          virialSumYY += virialyy;
-          virialSumZZ += virialzz;
-          virialSumXY += virialxy;
-          virialSumXZ += virialxz;
-          virialSumYZ += virialyz;
+        /**
+         * @copydoc Functor::SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool newton3)
+         */
+        void SoAFunctorPair(autopas::SoAView<SoAArraysType> soa1, autopas::SoAView<SoAArraysType> soa2, const bool newton3) final {
+            if (newton3) {
+                SoAFunctorPairImpl<true>(soa1, soa2);
+            } else {
+                SoAFunctorPairImpl<false>(soa1, soa2);
+            }
         }
-      }
 
-      fxptr[i] += fxacc;
-      fyptr[i] += fyacc;
-      fzptr[i] += fzacc;
-    }
-    if (calculateGlobals) {
-      const int threadnum = autopas_get_thread_num();
-      double factor = 1.;
-      // we assume newton3 to be enabled in this function call, thus we multiply
-      // by two if the value of newton3 is false, since for newton3 disabled we
-      // divide by two later on.
-      factor *= newton3 ? .5 : 1.;
-      _aosThreadData[threadnum].upotSum += upotSum * factor;
-      _aosThreadData[threadnum].virialSum[0] += virialSumXX * factor;
-      _aosThreadData[threadnum].virialSum[1] += virialSumYY * factor;
-      _aosThreadData[threadnum].virialSum[2] += virialSumZZ * factor;
-      _aosThreadData[threadnum].virialSum[3] += virialSumXY * factor;
-      _aosThreadData[threadnum].virialSum[4] += virialSumXZ * factor;
-      _aosThreadData[threadnum].virialSum[5] += virialSumYZ * factor;
-    }
-  }
+    private:
+        /**
+         * Implementation function of SoAFunctorPair(soa1, soa2, newton3)
+         *
+         * @tparam newton3
+         * @param soa1
+         * @param soa2
+         */
+        template <bool newton3>
+        void SoAFunctorPairImpl(autopas::SoAView<SoAArraysType> soa1, autopas::SoAView<SoAArraysType> soa2) {
+            using namespace autopas;
+            if (soa1.getNumberOfParticles() == 0 || soa2.getNumberOfParticles() == 0) return;
 
-  // clang-format off
-  /**
-   * @copydoc Functor::SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool newton3, bool cellWiseOwnedState)
-   */
-  // clang-format on
-  void SoAFunctorPair(autopas::SoAView<SoAArraysType> soa1,
-                      autopas::SoAView<SoAArraysType> soa2,
-                      const bool newton3) override {
-    using namespace autopas;
-    if (newton3) {
-      SoAFunctorPairImpl<true>(soa1, soa2);
-    } else {
-      SoAFunctorPairImpl<false>(soa1, soa2);
-    }
-  }
+            const auto *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
+            const auto *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
+            const auto *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+            const auto *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
+            const auto *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
+            const auto *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
+            const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle::AttributeNames::ownershipState>();
+            const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle::AttributeNames::ownershipState>();
 
-private:
-  /**
-   * Implementation function of SoAFunctorPair(soa1, soa2, newton3,
-   * cellWiseOwnedState)
-   *
-   * @tparam newton3
-   * @tparam cellWiseOwnedState
-   * @tparam duplicatedCalculations
-   * @param soa1
-   * @param soa2
-   */
-  template <bool newton3>
-  void SoAFunctorPairImpl(autopas::SoAView<SoAArraysType> soa1,
-                          autopas::SoAView<SoAArraysType> soa2) {
-    using namespace autopas;
-    if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0)
-      return;
+            auto *const __restrict fx1ptr = soa1.template begin<Particle::AttributeNames::forceX>();
+            auto *const __restrict fy1ptr = soa1.template begin<Particle::AttributeNames::forceY>();
+            auto *const __restrict fz1ptr = soa1.template begin<Particle::AttributeNames::forceZ>();
+            auto *const __restrict fx2ptr = soa2.template begin<Particle::AttributeNames::forceX>();
+            auto *const __restrict fy2ptr = soa2.template begin<Particle::AttributeNames::forceY>();
+            auto *const __restrict fz2ptr = soa2.template begin<Particle::AttributeNames::forceZ>();
+            [[maybe_unused]] auto *const __restrict typeptr1 = soa1.template begin<Particle::AttributeNames::typeId>();
+            [[maybe_unused]] auto *const __restrict typeptr2 = soa2.template begin<Particle::AttributeNames::typeId>();
 
-    const auto *const __restrict__ x1ptr =
-        soa1.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict__ y1ptr =
-        soa1.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict__ z1ptr =
-        soa1.template begin<Particle::AttributeNames::posZ>();
-    const auto *const __restrict__ x2ptr =
-        soa2.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict__ y2ptr =
-        soa2.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict__ z2ptr =
-        soa2.template begin<Particle::AttributeNames::posZ>();
-    const auto *const __restrict__ ownedStatePtr1 =
-        soa1.template begin<Particle::AttributeNames::ownershipState>();
-    const auto *const __restrict__ ownedStatePtr2 =
-        soa2.template begin<Particle::AttributeNames::ownershipState>();
+            // Checks whether the cells are halo cells.
+            SoAFloatPrecision upotSum = 0.;
+            SoAFloatPrecision virialSumXX = 0.;
+            SoAFloatPrecision virialSumYY = 0.;
+            SoAFloatPrecision virialSumZZ = 0.;
+            SoAFloatPrecision virialSumXY = 0.;
+            SoAFloatPrecision virialSumXZ = 0.;
+            SoAFloatPrecision virialSumYZ = 0.;
 
-    auto *const __restrict__ fx1ptr =
-        soa1.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict__ fy1ptr =
-        soa1.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict__ fz1ptr =
-        soa1.template begin<Particle::AttributeNames::forceZ>();
-    auto *const __restrict__ fx2ptr =
-        soa2.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict__ fy2ptr =
-        soa2.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict__ fz2ptr =
-        soa2.template begin<Particle::AttributeNames::forceZ>();
-    [[maybe_unused]] auto *const __restrict__ typeptr1 =
-        soa1.template begin<Particle::AttributeNames::typeId>();
-    [[maybe_unused]] auto *const __restrict__ typeptr2 =
-        soa2.template begin<Particle::AttributeNames::typeId>();
+            const SoAFloatPrecision cutoffsquare = _cutoffsquare;
+            SoAFloatPrecision shift6 = _shift6;
+            SoAFloatPrecision sigmasquare = _sigmasquare;
+            SoAFloatPrecision epsilon24 = _epsilon24;
 
-    SoAFloatPrecision upotSum = 0.;
-    SoAFloatPrecision virialSumXX = 0.;
-    SoAFloatPrecision virialSumYY = 0.;
-    SoAFloatPrecision virialSumZZ = 0.;
-    SoAFloatPrecision virialSumXY = 0.;
-    SoAFloatPrecision virialSumXZ = 0.;
-    SoAFloatPrecision virialSumYZ = 0.;
+            // preload all sigma and epsilons for next vectorized region
+            std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>> sigmaSquares;
+            std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>> epsilon24s;
+            std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>> shift6s;
+            if constexpr (useMixing) {
+                sigmaSquares.resize(soa2.getNumberOfParticles());
+                epsilon24s.resize(soa2.getNumberOfParticles());
+                // if no mixing or mixing but no shift shift6 is constant therefore we do not need this vector.
+                if constexpr (applyShift) {
+                    shift6s.resize(soa2.getNumberOfParticles());
+                }
+            }
 
-    const SoAFloatPrecision cutoffsquare = _cutoffsquare;
-    SoAFloatPrecision shift6 = _shift6;
-    SoAFloatPrecision sigmasquare = _sigmasquare;
-    SoAFloatPrecision epsilon24 = _epsilon24;
+            for (unsigned int i = 0; i < soa1.getNumberOfParticles(); ++i) {
+                SoAFloatPrecision fxacc = 0;
+                SoAFloatPrecision fyacc = 0;
+                SoAFloatPrecision fzacc = 0;
 
-    // preload all sigma and epsilons for next vectorized region
-    std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>>
-        sigmaSquares;
-    std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>>
-        epsilon24s;
-    std::vector<SoAFloatPrecision, AlignedAllocator<SoAFloatPrecision>> shift6s;
-    if constexpr (useMixing) {
-      sigmaSquares.resize(soa2.getNumParticles());
-      epsilon24s.resize(soa2.getNumParticles());
-      // if no mixing or mixing but no shift shift6 is constant therefore we do
-      // not need this vector.
-      if constexpr (applyShift) {
-        shift6s.resize(soa2.getNumParticles());
-      }
-    }
+                const auto ownedStateI = ownedStatePtr1[i];
+                if (ownedStateI == OwnershipState::dummy) {
+                    continue;
+                }
 
-    for (unsigned int i = 0; i < soa1.getNumParticles(); ++i) {
-      SoAFloatPrecision fxacc = 0;
-      SoAFloatPrecision fyacc = 0;
-      SoAFloatPrecision fzacc = 0;
-
-      const auto ownedStateI = ownedStatePtr1[i];
-      if (ownedStateI == OwnershipState::dummy) {
-        continue;
-      }
-
-      // preload all sigma and epsilons for next vectorized region
-      if constexpr (useMixing) {
-        for (unsigned int j = 0; j < soa2.getNumParticles(); ++j) {
-          sigmaSquares[j] =
-              _PPLibrary->mixingSigmaSquare(typeptr1[i], typeptr2[j]);
-          epsilon24s[j] = _PPLibrary->mixing24Epsilon(typeptr1[i], typeptr2[j]);
-          if constexpr (applyShift) {
-            shift6s[j] = _PPLibrary->mixingShift6(typeptr1[i], typeptr2[j]);
-          }
-        }
-      }
+                // preload all sigma and epsilons for next vectorized region
+                if constexpr (useMixing) {
+                    for (unsigned int j = 0; j < soa2.getNumberOfParticles(); ++j) {
+                        sigmaSquares[j] = _PPLibrary->mixingSigmaSquare(typeptr1[i], typeptr2[j]);
+                        epsilon24s[j] = _PPLibrary->mixing24Epsilon(typeptr1[i], typeptr2[j]);
+                        if constexpr (applyShift) {
+                            shift6s[j] = _PPLibrary->mixingShift6(typeptr1[i], typeptr2[j]);
+                        }
+                    }
+                }
 
 // icpc vectorizes this.
 // g++ only with -ffast-math or -funsafe-math-optimizations
 #pragma omp simd reduction(+ : fxacc, fyacc, fzacc, upotSum, virialSumXX, virialSumYY, virialSumZZ, virialSumXY, virialSumXZ, virialSumYZ)
-      for (unsigned int j = 0; j < soa2.getNumParticles(); ++j) {
-        if (!doesInteract(typeptr1[i], typeptr2[j]))
-          continue;
+                for (unsigned int j = 0; j < soa2.getNumberOfParticles(); ++j) {
+                    if(!doesInteract(typeptr1[i], typeptr2[j])) continue;
+             
+                    if constexpr (useMixing) {
+                        sigmasquare = sigmaSquares[j];
+                        epsilon24 = epsilon24s[j];
+                        if constexpr (applyShift) {
+                            shift6 = shift6s[j];
+                        }
+                    }
 
-        if constexpr (useMixing) {
-          sigmasquare = sigmaSquares[j];
-          epsilon24 = epsilon24s[j];
-          if constexpr (applyShift) {
-            shift6 = shift6s[j];
-          }
+                    const auto ownedStateJ = ownedStatePtr2[j];
+
+                    const SoAFloatPrecision drx = x1ptr[i] - x2ptr[j];
+                    const SoAFloatPrecision dry = y1ptr[i] - y2ptr[j];
+                    const SoAFloatPrecision drz = z1ptr[i] - z2ptr[j];
+
+                    const SoAFloatPrecision drx2 = drx * drx;
+                    const SoAFloatPrecision dry2 = dry * dry;
+                    const SoAFloatPrecision drz2 = drz * drz;
+
+                    const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
+
+                    // Mask away if distance is too large or any particle is a dummy.
+                    // Particle ownedStateI was already checked previously.
+                    const bool mask = dr2 <= cutoffsquare and ownedStateJ != OwnershipState::dummy;
+
+                    const SoAFloatPrecision invdr2 = 1. / dr2;
+                    const SoAFloatPrecision lj2 = sigmasquare * invdr2;
+                    const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
+                    const SoAFloatPrecision lj12 = lj6 * lj6;
+                    const SoAFloatPrecision lj12m6 = lj12 - lj6;
+                    const SoAFloatPrecision fac = mask ? epsilon24 * (lj12 + lj12m6) * invdr2 * mask : 0.;
+
+                    const SoAFloatPrecision fx = drx * fac;
+                    const SoAFloatPrecision fy = dry * fac;
+                    const SoAFloatPrecision fz = drz * fac;
+
+                    fxacc += fx;
+                    fyacc += fy;
+                    fzacc += fz;
+                    if (newton3) {
+                        fx2ptr[j] -= fx;
+                        fy2ptr[j] -= fy;
+                        fz2ptr[j] -= fz;
+                    }
+
+                    if constexpr (calculateGlobals) {
+                        SoAFloatPrecision virialxx = drx * fx;
+                        SoAFloatPrecision virialyy = dry * fy;
+                        SoAFloatPrecision virialzz = drz * fz;
+                        SoAFloatPrecision virialxy = drx * fy;
+                        SoAFloatPrecision virialxz = drx * fz;
+                        SoAFloatPrecision virialyz = dry * fz;
+                        SoAFloatPrecision upot = (epsilon24 * lj12m6 + shift6) * mask;
+
+                        SoAFloatPrecision energyFactor = (ownedStateI == OwnershipState::owned ? 1. : 0.);
+                        if constexpr (newton3) {
+                            energyFactor += (ownedStateJ == OwnershipState::owned ? 1. : 0.);
+                        }
+
+                        // if newton3 is enabled, we multiply by 0.5 at the end of this function call when adding up the values to
+                        // the threadData.
+                        upotSum += upot * energyFactor;
+                        virialSumXX += virialxx * energyFactor;
+                        virialSumYY += virialyy * energyFactor;
+                        virialSumZZ += virialzz * energyFactor;
+                        virialSumXY += virialxy * energyFactor;
+                        virialSumXZ += virialxz * energyFactor;
+                        virialSumYZ += virialyz * energyFactor;
+                    }
+                }
+                fx1ptr[i] += fxacc;
+                fy1ptr[i] += fyacc;
+                fz1ptr[i] += fzacc;
+            }
+            if (calculateGlobals) {
+                const int threadnum = autopas_get_thread_num();
+                SoAFloatPrecision newton3Factor = 1.;
+                if constexpr (newton3) {
+                    newton3Factor *= 0.5;  // we count the energies partly to one of the two cells!
+                }
+                _aosThreadData[threadnum].upotSum += upotSum * newton3Factor;
+                _aosThreadData[threadnum].virialSum[0] += virialSumXX * newton3Factor;
+                _aosThreadData[threadnum].virialSum[1] += virialSumYY * newton3Factor;
+                _aosThreadData[threadnum].virialSum[2] += virialSumZZ * newton3Factor;
+                _aosThreadData[threadnum].virialSum[3] += virialSumXY * newton3Factor;
+                _aosThreadData[threadnum].virialSum[4] += virialSumXZ * newton3Factor;
+                _aosThreadData[threadnum].virialSum[5] += virialSumYZ * newton3Factor;
+            }
         }
 
-        const auto ownedStateJ = ownedStatePtr2[j];
-
-        const SoAFloatPrecision drx = x1ptr[i] - x2ptr[j];
-        const SoAFloatPrecision dry = y1ptr[i] - y2ptr[j];
-        const SoAFloatPrecision drz = z1ptr[i] - z2ptr[j];
-
-        const SoAFloatPrecision drx2 = drx * drx;
-        const SoAFloatPrecision dry2 = dry * dry;
-        const SoAFloatPrecision drz2 = drz * drz;
-
-        const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
-
-        // Mask away if distance is too large or any particle is a dummy.
-        // Particle ownedStateI was already checked previously.
-        const bool mask =
-            dr2 <= cutoffsquare and ownedStateJ != OwnershipState::dummy;
-
-        const SoAFloatPrecision invdr2 = 1. / dr2;
-        const SoAFloatPrecision lj2 = sigmasquare * invdr2;
-        const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
-        const SoAFloatPrecision lj12 = lj6 * lj6;
-        const SoAFloatPrecision lj12m6 = lj12 - lj6;
-        const SoAFloatPrecision fac =
-            mask ? epsilon24 * (lj12 + lj12m6) * invdr2 * mask : 0.;
-
-        const SoAFloatPrecision fx = drx * fac;
-        const SoAFloatPrecision fy = dry * fac;
-        const SoAFloatPrecision fz = drz * fac;
-
-        fxacc += fx;
-        fyacc += fy;
-        fzacc += fz;
-        if (newton3) {
-          fx2ptr[j] -= fx;
-          fy2ptr[j] -= fy;
-          fz2ptr[j] -= fz;
+    public:
+        // clang-format off
+        /**
+         * @copydoc Functor::SoAFunctorVerlet(SoAView<SoAArraysType> soa, const size_t indexFirst, const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList, bool newton3)
+         * @note If you want to parallelize this by openmp, please ensure that there
+         * are no dependencies, i.e. introduce colors!
+         */
+        // clang-format on
+        void SoAFunctorVerlet(autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
+                              const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList,
+                              bool newton3) final {
+            using namespace autopas;
+            if (soa.getNumberOfParticles() == 0 or neighborList.empty()) return;
+            if (newton3) {
+                SoAFunctorVerletImpl<true>(soa, indexFirst, neighborList);
+            } else {
+                SoAFunctorVerletImpl<false>(soa, indexFirst, neighborList);
+            }
         }
 
-        if constexpr (calculateGlobals) {
-          const SoAFloatPrecision virialxx = drx * fx;
-          const SoAFloatPrecision virialyy = dry * fy;
-          const SoAFloatPrecision virialzz = drz * fz;
-          const SoAFloatPrecision virialxy = drx * fy;
-          const SoAFloatPrecision virialxz = drx * fz;
-          const SoAFloatPrecision virialyz = dry * fz;
-          SoAFloatPrecision upot = (epsilon24 * lj12m6 + shift6) * mask;
-
-          SoAFloatPrecision energyFactor =
-              (ownedStateI == OwnershipState::owned ? 1. : 0.);
-          if constexpr (newton3) {
-            energyFactor += (ownedStateJ == OwnershipState::owned ? 1. : 0.);
-          }
-
-          // if newton3 is enabled, we multiply by 0.5 at the end of this
-          // function call when adding up the values to the threadData.
-          upotSum += upot * energyFactor;
-          virialSumXX += virialxx * energyFactor;
-          virialSumYY += virialyy * energyFactor;
-          virialSumZZ += virialzz * energyFactor;
-          virialSumXY += virialxy * energyFactor;
-          virialSumXZ += virialxz * energyFactor;
-          virialSumYZ += virialyz * energyFactor;
+        /**
+         * Sets the particle properties constants for this functor.
+         *
+         * This is only necessary if no particlePropertiesLibrary is used.
+         *
+         * @param epsilon24
+         * @param sigmaSquare
+         */
+        void setParticleProperties(SoAFloatPrecision epsilon24, SoAFloatPrecision sigmaSquare) {
+            using namespace autopas;
+            _epsilon24 = epsilon24;
+            _sigmasquare = sigmaSquare;
+            if (applyShift) {
+                _shift6 = ParticlePropertiesLibrary<double, size_t>::calcShift6(_epsilon24, _sigmasquare, _cutoffsquare);
+            } else {
+                _shift6 = 0.;
+            }
         }
-      }
-      fx1ptr[i] += fxacc;
-      fy1ptr[i] += fyacc;
-      fz1ptr[i] += fzacc;
-    }
-    if (calculateGlobals) {
-      const int threadnum = autopas_get_thread_num();
-      SoAFloatPrecision newton3Factor = 1.;
-      if constexpr (newton3) {
-        newton3Factor *=
-            0.5; // we count the energies partly to one of the two cells!
-      }
 
-      _aosThreadData[threadnum].upotSum += upotSum * newton3Factor;
-      _aosThreadData[threadnum].virialSum[0] += virialSumXX * newton3Factor;
-      _aosThreadData[threadnum].virialSum[1] += virialSumYY * newton3Factor;
-      _aosThreadData[threadnum].virialSum[2] += virialSumZZ * newton3Factor;
-      _aosThreadData[threadnum].virialSum[3] += virialSumXY * newton3Factor;
-      _aosThreadData[threadnum].virialSum[4] += virialSumXZ * newton3Factor;
-      _aosThreadData[threadnum].virialSum[5] += virialSumYZ * newton3Factor;
-    }
-  }
+        /**
+         * @copydoc Functor::getNeededAttr()
+         */
+        constexpr static auto getNeededAttr() {
+            return std::array<typename Particle::AttributeNames, 9>{
+                    Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+                    Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
+                    Particle::AttributeNames::forceZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
+        }
 
-public:
-  // clang-format off
-  /**
-   * @copydoc Functor::SoAFunctorVerlet(SoAView<SoAArraysType> soa, const size_t indexFirst, const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList, bool newton3)
-   * @note If you want to parallelize this by openmp, please ensure that there
-   * are no dependencies, i.e. introduce colors!
-   */
-  // clang-format on
-  void
-  SoAFunctorVerlet(autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
-                   const std::vector<size_t, autopas::AlignedAllocator<size_t>>
-                       &neighborList,
-                   bool newton3) override {
-    using namespace autopas;
-    if (soa.getNumParticles() == 0 or neighborList.empty())
-      return;
-    if (newton3) {
-      SoAFunctorVerletImpl<true>(soa, indexFirst, neighborList);
-    } else {
-      SoAFunctorVerletImpl<false>(soa, indexFirst, neighborList);
-    }
-  }
+        /**
+         * @copydoc Functor::getNeededAttr(std::false_type)
+         */
+        constexpr static auto getNeededAttr(std::false_type) {
+            return std::array<typename Particle::AttributeNames, 6>{
+                    Particle::AttributeNames::id,   Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+                    Particle::AttributeNames::posZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
+        }
 
-  /**
-   * @brief Functor using Cuda on SoA in device Memory
-   *
-   * This Functor calculates the pair-wise interactions between particles in the
-   * device_handle on the GPU
-   *
-   * @param device_handle soa in device memory
-   * @param newton3 defines whether or whether not to use newton
-   */
-  void CudaFunctor(
-      autopas::CudaSoA<typename Particle::CudaDeviceArraysType> &device_handle,
-      bool newton3) override {
-    using namespace autopas;
-#if defined(AUTOPAS_CUDA)
-    const size_t size =
-        device_handle.template get<Particle::AttributeNames::posX>().size();
-    if (size == 0) {
-      return;
-    }
-    auto cudaSoA = this->createFunctorCudaSoA(device_handle);
-    if (newton3) {
-      _cudawrapper.SoAFunctorN3Wrapper(cudaSoA.get(), 0);
-    } else {
-      _cudawrapper.SoAFunctorNoN3Wrapper(cudaSoA.get(), 0);
-    }
+        /**
+         * @copydoc Functor::getComputedAttr()
+         */
+        constexpr static auto getComputedAttr() {
+            return std::array<typename Particle::AttributeNames, 3>{
+                    Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
+        }
 
-#else
-    utils::ExceptionHandler::exception(
-        "LJFunctor::CudaFunctor: AutoPas was compiled without CUDA support!");
-#endif
-  }
+        /**
+         *
+         * @return useMixing
+         */
+        constexpr static bool getMixing() { return useMixing; }
 
-  /**
-   * Sets the particle properties constants for this functor.
-   *
-   * This is only necessary if no particlePropertiesLibrary is used.
-   * If compiled with CUDA this function also loads the values to the GPU.
-   *
-   * @param epsilon24
-   * @param sigmaSquare
-   */
-  void setParticleProperties(SoAFloatPrecision epsilon24,
-                             SoAFloatPrecision sigmaSquare) {
-    using namespace autopas;
-    _epsilon24 = epsilon24;
-    _sigmasquare = sigmaSquare;
-    if (applyShift) {
-      _shift6 = ParticlePropertiesLibrary<double, size_t>::calcShift6(
-          _epsilon24, _sigmasquare, _cutoffsquare);
-    } else {
-      _shift6 = 0.;
-    }
-#if defined(AUTOPAS_CUDA)
-    LJFunctorConstants<SoAFloatPrecision> constants(
-        _cutoffsquare, _epsilon24 /* epsilon24 */,
-        _sigmasquare /* sigmasquare */, _shift6);
-    _cudawrapper.loadConstants(&constants);
-#endif
-  }
-  /**
-   * @brief Functor using Cuda on SoAs in device Memory
-   *
-   * This Functor calculates the pair-wise interactions between particles in the
-   * device_handle1 and device_handle2 on the GPU
-   *
-   * @param device_handle1 first soa in device memory
-   * @param device_handle2 second soa in device memory
-   * @param newton3 defines whether or whether not to use newton
-   */
-  void CudaFunctor(
-      autopas::CudaSoA<typename Particle::CudaDeviceArraysType> &device_handle1,
-      autopas::CudaSoA<typename Particle::CudaDeviceArraysType> &device_handle2,
-      bool newton3) override {
-    using namespace autopas;
-#if defined(AUTOPAS_CUDA)
-    const size_t size1 =
-        device_handle1.template get<Particle::AttributeNames::posX>().size();
-    const size_t size2 =
-        device_handle2.template get<Particle::AttributeNames::posX>().size();
-    if ((size1 == 0) or (size2 == 0)) {
-      return;
-    }
-    auto cudaSoA1 = this->createFunctorCudaSoA(device_handle1);
-    auto cudaSoA2 = this->createFunctorCudaSoA(device_handle2);
+        /**
+         * Get the number of flops used per kernel call. This should count the
+         * floating point operations needed for two particles that lie within a cutoff
+         * radius.
+         * @return the number of floating point operations
+         */
+        static unsigned long getNumFlopsPerKernelCall() {
+            // Kernel: 12 = 1 (inverse R squared) + 8 (compute scale) + 3 (apply
+            // scale) sum Forces: 6 (forces) kernel total = 12 + 6 = 18
+            return 18ul;
+        }
 
-    if (newton3) {
-      if (size1 > size2) {
-        _cudawrapper.SoAFunctorN3PairWrapper(cudaSoA1.get(), cudaSoA2.get(), 0);
-      } else {
-        _cudawrapper.SoAFunctorN3PairWrapper(cudaSoA2.get(), cudaSoA1.get(), 0);
-      }
-    } else {
-      _cudawrapper.SoAFunctorNoN3PairWrapper(cudaSoA1.get(), cudaSoA2.get(), 0);
-    }
-#else
-    utils::ExceptionHandler::exception(
-        "AutoPas was compiled without CUDA support!");
-#endif
-  }
-#if defined(AUTOPAS_CUDA)
-  CudaWrapperInterface<SoAFloatPrecision> *getCudaWrapper() override {
-    return &_cudawrapper;
-  }
+        /**
+         * Reset the global values.
+         * Will set the global values to zero to prepare for the next iteration.
+         */
+        void initTraversal() final {
+            using namespace autopas;
+            _upotSum = 0.;
+            _virialSum = {0., 0., 0., 0., 0., 0.};
+            _postProcessed = false;
+            for (size_t i = 0; i < _aosThreadData.size(); ++i) {
+                _aosThreadData[i].setZero();
+            }
+        }
 
-  std::unique_ptr<FunctorCudaSoA<SoAFloatPrecision>> createFunctorCudaSoA(
-      CudaSoA<typename Particle::CudaDeviceArraysType> &device_handle)
-      override {
-    if (calculateGlobals) {
-      return std::make_unique<LJFunctorCudaGlobalsSoA<SoAFloatPrecision>>(
-          device_handle.template get<Particle::AttributeNames::posX>().size(),
-          device_handle.template get<Particle::AttributeNames::posX>().get(),
-          device_handle.template get<Particle::AttributeNames::posY>().get(),
-          device_handle.template get<Particle::AttributeNames::posZ>().get(),
-          device_handle.template get<Particle::AttributeNames::forceX>().get(),
-          device_handle.template get<Particle::AttributeNames::forceY>().get(),
-          device_handle.template get<Particle::AttributeNames::forceZ>().get(),
-          device_handle.template get<Particle::AttributeNames::ownershipState>()
-              .get(),
-          _cudaGlobals.get());
-    } else {
-      return std::make_unique<LJFunctorCudaSoA<SoAFloatPrecision>>(
-          device_handle.template get<Particle::AttributeNames::posX>().size(),
-          device_handle.template get<Particle::AttributeNames::posX>().get(),
-          device_handle.template get<Particle::AttributeNames::posY>().get(),
-          device_handle.template get<Particle::AttributeNames::posZ>().get(),
-          device_handle.template get<Particle::AttributeNames::forceX>().get(),
-          device_handle.template get<Particle::AttributeNames::forceY>().get(),
-          device_handle.template get<Particle::AttributeNames::forceZ>().get());
-    }
-  }
-#endif
+        /**
+         * Postprocesses global values, e.g. upot and virial
+         * @param newton3
+         */
+        void endTraversal(bool newton3) final {
+            using namespace autopas;
+            if (_postProcessed) {
+                throw utils::ExceptionHandler::AutoPasException(
+                        "Already postprocessed, endTraversal(bool newton3) was called twice without calling initTraversal().");
+            }
+            if (calculateGlobals) {
+                for (size_t i = 0; i < _aosThreadData.size(); ++i) {
+                    _upotSum += _aosThreadData[i].upotSum;
+                    _virialSum = utils::ArrayMath::add(_virialSum, _aosThreadData[i].virialSum);
+                }
+                if (not newton3) {
+                    // if the newton3 optimization is disabled we have added every energy contribution twice, so we divide by 2
+                    // here.
+                    _upotSum *= 0.5;
+                    _virialSum = utils::ArrayMath::mulScalar(_virialSum, 0.5);
+                }
+                // we have always calculated 6*upot, so we divide by 6 here!
+                _upotSum /= 6.;
+                _postProcessed = true;
+            }
+        }
 
-  /**
-   * @copydoc Functor::deviceSoALoader
-   */
-  void deviceSoALoader(::autopas::SoA<SoAArraysType> &soa,
-                       autopas::CudaSoA<typename Particle::CudaDeviceArraysType>
-                           &device_handle) override {
-    using namespace autopas;
-#if defined(AUTOPAS_CUDA)
+        /**
+         * Get the potential Energy.
+         * @return the potential Energy
+         */
+        double getUpot() {
+            using namespace autopas;
+            if (not calculateGlobals) {
+                throw utils::ExceptionHandler::AutoPasException(
+                        "Trying to get upot even though calculateGlobals is false. If you want this functor to calculate global "
+                        "values, please specify calculateGlobals to be true.");
+            }
+            if (not _postProcessed) {
+                throw utils::ExceptionHandler::AutoPasException("Cannot get upot, because endTraversal was not called.");
+            }
+            return _upotSum;
+        }
 
-    const size_t size = soa.getNumParticles();
-    if (size == 0)
-      return;
+        /**
+         * Get the virial.
+         * @return
+         */
+        std::array<double, 6>* getVirial() {
+            using namespace autopas;
+            if (not calculateGlobals) {
+                throw utils::ExceptionHandler::AutoPasException(
+                        "Trying to get virial even though calculateGlobals is false. If you want this functor to calculate global "
+                        "values, please specify calculateGlobals to be true.");
+            }
+            if (not _postProcessed) {
+                throw utils::ExceptionHandler::AutoPasException("Cannot get virial, because endTraversal was not called.");
+            }
+            return &_virialSum;
+        }
 
-    device_handle.template get<Particle::AttributeNames::posX>()
-        .copyHostToDevice(size,
-                          soa.template begin<Particle::AttributeNames::posX>());
-    device_handle.template get<Particle::AttributeNames::posY>()
-        .copyHostToDevice(size,
-                          soa.template begin<Particle::AttributeNames::posY>());
-    device_handle.template get<Particle::AttributeNames::posZ>()
-        .copyHostToDevice(size,
-                          soa.template begin<Particle::AttributeNames::posZ>());
+        /**
+         * Getter for 24*epsilon.
+         * @return 24*epsilon
+         */
+        SoAFloatPrecision getEpsilon24() const { return _epsilon24; }
 
-    device_handle.template get<Particle::AttributeNames::forceX>()
-        .copyHostToDevice(
-            size, soa.template begin<Particle::AttributeNames::forceX>());
-    device_handle.template get<Particle::AttributeNames::forceY>()
-        .copyHostToDevice(
-            size, soa.template begin<Particle::AttributeNames::forceY>());
-    device_handle.template get<Particle::AttributeNames::forceZ>()
-        .copyHostToDevice(
-            size, soa.template begin<Particle::AttributeNames::forceZ>());
+        /**
+         * Getter for the squared sigma.
+         * @return squared sigma.
+         */
+        SoAFloatPrecision getSigmaSquare() const { return _sigmasquare; }
 
-    if (calculateGlobals) {
-      device_handle.template get<Particle::AttributeNames::ownershipState>()
-          .copyHostToDevice(
-              size,
-              soa.template begin<Particle::AttributeNames::ownershipState>());
-    }
+    private:
+        template <bool newton3>
+        void SoAFunctorVerletImpl(autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
+                                  const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList) {
+            using namespace autopas;
+            const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+            const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+            const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
-#else
-    utils::ExceptionHandler::exception("LJFunctor::deviceSoALoader: AutoPas "
-                                       "was compiled without CUDA support!");
-#endif
-  }
+            auto *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
+            auto *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
+            auto *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
+            [[maybe_unused]] auto *const __restrict__ typeptr = soa.template begin<Particle::AttributeNames::typeId>();
 
-  /**
-   * @copydoc Functor::deviceSoAExtractor
-   */
-  void
-  deviceSoAExtractor(::autopas::SoA<SoAArraysType> &soa,
-                     autopas::CudaSoA<typename Particle::CudaDeviceArraysType>
-                         &device_handle) override {
-    using namespace autopas;
-#if defined(AUTOPAS_CUDA)
+            const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
 
-    const size_t size = soa.getNumParticles();
-    if (size == 0)
-      return;
+            const SoAFloatPrecision cutoffsquare = _cutoffsquare;
+            SoAFloatPrecision shift6 = _shift6;
+            SoAFloatPrecision sigmasquare = _sigmasquare;
+            SoAFloatPrecision epsilon24 = _epsilon24;
 
-    device_handle.template get<Particle::AttributeNames::forceX>()
-        .copyDeviceToHost(
-            size, soa.template begin<Particle::AttributeNames::forceX>());
-    device_handle.template get<Particle::AttributeNames::forceY>()
-        .copyDeviceToHost(
-            size, soa.template begin<Particle::AttributeNames::forceY>());
-    device_handle.template get<Particle::AttributeNames::forceZ>()
-        .copyDeviceToHost(
-            size, soa.template begin<Particle::AttributeNames::forceZ>());
+            SoAFloatPrecision upotSum = 0.;
+            SoAFloatPrecision virialSumXX = 0.;
+            SoAFloatPrecision virialSumYY = 0.;
+            SoAFloatPrecision virialSumZZ = 0.;
+            SoAFloatPrecision virialSumXY = 0.;
+            SoAFloatPrecision virialSumXZ = 0.;
+            SoAFloatPrecision virialSumYZ = 0.;
 
-#else
-    utils::ExceptionHandler::exception("LJFunctor::deviceSoAExtractor: AutoPas "
-                                       "was compiled without CUDA support!");
-#endif
-  }
+            SoAFloatPrecision fxacc = 0;
+            SoAFloatPrecision fyacc = 0;
+            SoAFloatPrecision fzacc = 0;
+            const size_t neighborListSize = neighborList.size();
+            const size_t *const __restrict neighborListPtr = neighborList.data();
 
-  /**
-   * @copydoc Functor::getNeededAttr()
-   */
-  constexpr static auto getNeededAttr() {
-    return std::array<typename Particle::AttributeNames, 9>{
-        Particle::AttributeNames::id,
-        Particle::AttributeNames::posX,
-        Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ,
-        Particle::AttributeNames::forceX,
-        Particle::AttributeNames::forceY,
-        Particle::AttributeNames::forceZ,
-        Particle::AttributeNames::typeId,
-        Particle::AttributeNames::ownershipState};
-  }
+            // checks whether particle i is owned.
+            const auto ownedStateI = ownedStatePtr[indexFirst];
+            if (ownedStateI == OwnershipState::dummy) {
+                return;
+            }
 
-  /**
-   * @copydoc Functor::getNeededAttr(std::false_type)
-   */
-  constexpr static auto getNeededAttr(std::false_type) {
-    return std::array<typename Particle::AttributeNames, 6>{
-        Particle::AttributeNames::id,
-        Particle::AttributeNames::posX,
-        Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ,
-        Particle::AttributeNames::typeId,
-        Particle::AttributeNames::ownershipState};
-  }
-
-  /**
-   * @copydoc Functor::getComputedAttr()
-   */
-  constexpr static auto getComputedAttr() {
-    return std::array<typename Particle::AttributeNames, 3>{
-        Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-        Particle::AttributeNames::forceZ};
-  }
-
-  /**
-   * Get the number of flops used per kernel call. This should count the
-   * floating point operations needed for two particles that lie within a cutoff
-   * radius.
-   * @return the number of floating point operations
-   */
-  static unsigned long getNumFlopsPerKernelCall() {
-    // Kernel: 12 = 1 (inverse R squared) + 8 (compute scale) + 3 (apply
-    // scale) sum Forces: 6 (forces) kernel total = 12 + 6 = 18
-    return 18ul;
-  }
-
-  /**
-   * Reset the global values.
-   * Will set the global values to zero to prepare for the next iteration.
-   */
-  void initTraversal() override {
-    using namespace autopas;
-    _upotSum = 0.;
-    _virialSum = {0., 0., 0., 0., 0., 0.};
-    _postProcessed = false;
-    for (size_t i = 0; i < _aosThreadData.size(); ++i) {
-      _aosThreadData[i].setZero();
-    }
-#if defined(AUTOPAS_CUDA)
-    if (calculateGlobals) {
-      std::array<SoAFloatPrecision, 7> globals{0, 0, 0, 0, 0, 0, 0};
-      _cudaGlobals.copyHostToDevice(7, globals.data());
-    }
-#endif
-  }
-
-  /**
-   * Postprocesses global values, e.g. upot and virial
-   * @param newton3
-   */
-  void endTraversal(bool newton3) override {
-    using namespace autopas;
-    if (_postProcessed) {
-      throw utils::ExceptionHandler::AutoPasException(
-          "Already postprocessed, endTraversal(bool newton3) was called twice "
-          "without calling initTraversal().");
-    }
-    if (calculateGlobals) {
-#if defined(AUTOPAS_CUDA)
-      std::array<SoAFloatPrecision, 7> globals{0, 0, 0, 0, 0, 0, 0};
-      _cudaGlobals.copyDeviceToHost(7, globals.data());
-      _virialSum[0] += globals[0];
-      _virialSum[1] += globals[1];
-      _virialSum[2] += globals[2];
-      _virialSum[3] += globals[3];
-      _virialSum[4] += globals[4];
-      _virialSum[5] += globals[5];
-      _upotSum += globals[3];
-#endif
-      for (size_t i = 0; i < _aosThreadData.size(); ++i) {
-        _upotSum += _aosThreadData[i].upotSum;
-        _virialSum =
-            utils::ArrayMath::add(_virialSum, _aosThreadData[i].virialSum);
-      }
-      if (not newton3) {
-        // if the newton3 optimization is disabled we have added every energy
-        // contribution twice, so we divide by 2 here.
-        _upotSum *= 0.5;
-        _virialSum = utils::ArrayMath::mulScalar(_virialSum, 0.5);
-      }
-      // we have always calculated 6*upot, so we divide by 6 here!
-      _upotSum /= 6.;
-      _postProcessed = true;
-    }
-  }
-
-  /**
-   * Get the potential Energy.
-   * @return the potential Energy
-   */
-  double getUpot() {
-    using namespace autopas;
-    if (not calculateGlobals) {
-      throw utils::ExceptionHandler::AutoPasException(
-          "Trying to get upot even though calculateGlobals is false. If you "
-          "want this functor to calculate global "
-          "values, please specify calculateGlobals to be true.");
-    }
-    if (not _postProcessed) {
-      throw utils::ExceptionHandler::AutoPasException(
-          "Cannot get upot, because endTraversal was not called.");
-    }
-    return _upotSum;
-  }
-
-  /**
-   * Get the virial.
-   * @return
-   */
-  std::array<double, 6> *getVirial() {
-    using namespace autopas;
-    if (not calculateGlobals) {
-      throw utils::ExceptionHandler::AutoPasException(
-          "Trying to get virial even though calculateGlobals is false. If you "
-          "want this functor to calculate global "
-          "values, please specify calculateGlobals to be true.");
-    }
-    if (not _postProcessed) {
-      throw utils::ExceptionHandler::AutoPasException(
-          "Cannot get virial, because endTraversal was not called.");
-    }
-    return &_virialSum;
-  }
-
-  /**
-   * Getter for 24*epsilon.
-   * @return 24*epsilon
-   */
-  SoAFloatPrecision getEpsilon24() const { return _epsilon24; }
-
-  /**
-   * Getter for the squared sigma.
-   * @return squared sigma.
-   */
-  SoAFloatPrecision getSigmaSquare() const { return _sigmasquare; }
-
-private:
-  template <bool newton3>
-  void SoAFunctorVerletImpl(
-      autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
-      const std::vector<size_t, autopas::AlignedAllocator<size_t>>
-          &neighborList) {
-    using namespace autopas;
-
-    const auto *const __restrict__ xptr =
-        soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict__ yptr =
-        soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict__ zptr =
-        soa.template begin<Particle::AttributeNames::posZ>();
-
-    auto *const __restrict__ fxptr =
-        soa.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict__ fyptr =
-        soa.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict__ fzptr =
-        soa.template begin<Particle::AttributeNames::forceZ>();
-    [[maybe_unused]] auto *const __restrict__ typeptr1 =
-        soa.template begin<Particle::AttributeNames::typeId>();
-    [[maybe_unused]] auto *const __restrict__ typeptr2 =
-        soa.template begin<Particle::AttributeNames::typeId>();
-
-    const auto *const __restrict__ ownedStatePtr =
-        soa.template begin<Particle::AttributeNames::ownershipState>();
-
-    const SoAFloatPrecision cutoffsquare = _cutoffsquare;
-    SoAFloatPrecision shift6 = _shift6;
-    SoAFloatPrecision sigmasquare = _sigmasquare;
-    SoAFloatPrecision epsilon24 = _epsilon24;
-
-    SoAFloatPrecision upotSum = 0.;
-    SoAFloatPrecision virialSumXX = 0.;
-    SoAFloatPrecision virialSumYY = 0.;
-    SoAFloatPrecision virialSumZZ = 0.;
-    SoAFloatPrecision virialSumXY = 0.;
-    SoAFloatPrecision virialSumXZ = 0.;
-    SoAFloatPrecision virialSumYZ = 0.;
-
-    SoAFloatPrecision fxacc = 0;
-    SoAFloatPrecision fyacc = 0;
-    SoAFloatPrecision fzacc = 0;
-    const size_t neighborListSize = neighborList.size();
-    const size_t *const __restrict__ neighborListPtr = neighborList.data();
-
-    // checks whether particle i is owned.
-    const auto ownedStateI = ownedStatePtr[indexFirst];
-    if (ownedStateI == OwnershipState::dummy) {
-      return;
-    }
-
-    // this is a magic number, that should correspond to at least
-    // vectorization width*N have testet multiple sizes:
-    // 4: does not give a speedup, slower than original AoSFunctor
-    // 8: small speedup compared to AoS
-    // 12: highest speedup compared to Aos
-    // 16: smaller speedup
-    // in theory this is a variable, we could auto-tune over...
+            // this is a magic number, that should correspond to at least
+            // vectorization width*N have testet multiple sizes:
+            // 4: does not give a speedup, slower than original AoSFunctor
+            // 8: small speedup compared to AoS
+            // 12: highest speedup compared to Aos
+            // 16: smaller speedup
+            // in theory this is a variable, we could auto-tune over...
 #ifdef __AVX512F__
-    // use a multiple of 8 for avx
+            // use a multiple of 8 for avx
     constexpr size_t vecsize = 16;
 #else
-    // for everything else 12 is faster
-    constexpr size_t vecsize = 12;
+            // for everything else 12 is faster
+            constexpr size_t vecsize = 12;
 #endif
-    size_t joff = 0;
+            size_t joff = 0;
 
-    // if the size of the verlet list is larger than the given size vecsize,
-    // we will use a vectorized version.
-    if (neighborListSize >= vecsize) {
-      alignas(64) std::array<SoAFloatPrecision, vecsize> xtmp, ytmp, ztmp,
-          typetmp, xArr, yArr, zArr, fxArr, fyArr, fzArr,
-          typeArr;
-      alignas(64) std::array<OwnershipState, vecsize> ownedStateArr{};
-      // broadcast of the position of particle i
-      for (size_t tmpj = 0; tmpj < vecsize; tmpj++) {
-        xtmp[tmpj] = xptr[indexFirst];
-        ytmp[tmpj] = yptr[indexFirst];
-        ztmp[tmpj] = zptr[indexFirst];
-        typetmp[tmpj] = typeptr1[indexFirst];
-      }
-      // loop over the verlet list from 0 to x*vecsize
-      for (; joff < neighborListSize - vecsize + 1; joff += vecsize) {
-        // in each iteration we calculate the interactions of particle i with
-        // vecsize particles in the neighborlist of particle i starting at
-        // particle joff
-        [[maybe_unused]] alignas(DEFAULT_CACHE_LINE_SIZE)
-            std::array<SoAFloatPrecision, vecsize>
-                sigmaSquares;
-        [[maybe_unused]] alignas(DEFAULT_CACHE_LINE_SIZE)
-            std::array<SoAFloatPrecision, vecsize>
-                epsilon24s;
-        [[maybe_unused]] alignas(DEFAULT_CACHE_LINE_SIZE)
-            std::array<SoAFloatPrecision, vecsize>
-                shift6s;
-        if constexpr (useMixing) {
-          for (size_t j = 0; j < vecsize; j++) {
-            sigmaSquares[j] = _PPLibrary->mixingSigmaSquare(
-                typeptr1[indexFirst], typeptr2[neighborListPtr[joff + j]]);
-            epsilon24s[j] = _PPLibrary->mixing24Epsilon(
-                typeptr1[indexFirst], typeptr2[neighborListPtr[joff + j]]);
-            if constexpr (applyShift) {
-              shift6s[j] = _PPLibrary->mixingShift6(
-                  typeptr1[indexFirst], typeptr2[neighborListPtr[joff + j]]);
-            }
-          }
-        }
+            // if the size of the verlet list is larger than the given size vecsize,
+            // we will use a vectorized version.
+            if (neighborListSize >= vecsize) {
+                alignas(64) std::array<SoAFloatPrecision, vecsize> xtmp, ytmp, ztmp, typetmp, xArr, yArr, zArr, fxArr, fyArr, fzArr, typeArr;
+                alignas(64) std::array<OwnershipState, vecsize> ownedStateArr{};
+                // broadcast of the position of particle i
+                for (size_t tmpj = 0; tmpj < vecsize; tmpj++) {
+                    xtmp[tmpj] = xptr[indexFirst];
+                    ytmp[tmpj] = yptr[indexFirst];
+                    ztmp[tmpj] = zptr[indexFirst];
+                    typetmp[tmpj] = typeptr[indexFirst];  
+                }
+                // loop over the verlet list from 0 to x*vecsize
+                for (; joff < neighborListSize - vecsize + 1; joff += vecsize) {
+                    // in each iteration we calculate the interactions of particle i with
+                    // vecsize particles in the neighborlist of particle i starting at
+                    // particle joff
 
-        // gather position of particle j
+                    [[maybe_unused]] alignas(DEFAULT_CACHE_LINE_SIZE) std::array<SoAFloatPrecision, vecsize> sigmaSquares;
+                    [[maybe_unused]] alignas(DEFAULT_CACHE_LINE_SIZE) std::array<SoAFloatPrecision, vecsize> epsilon24s;
+                    [[maybe_unused]] alignas(DEFAULT_CACHE_LINE_SIZE) std::array<SoAFloatPrecision, vecsize> shift6s;
+                    if constexpr (useMixing) {
+                        for (size_t j = 0; j < vecsize; j++) {
+                            sigmaSquares[j] = _PPLibrary->mixingSigmaSquare(typeptr[indexFirst], typeptr[neighborListPtr[joff + j]]);
+                            epsilon24s[j] = _PPLibrary->mixing24Epsilon(typeptr[indexFirst], typeptr[neighborListPtr[joff + j]]);
+                            if constexpr (applyShift) {
+                                shift6s[j] = _PPLibrary->mixingShift6(typeptr[indexFirst], typeptr[neighborListPtr[joff + j]]);
+                            }
+                        }
+                    }
+
+                    // gather position of particle j
 #pragma omp simd safelen(vecsize)
-        for (size_t tmpj = 0; tmpj < vecsize; tmpj++) {
-          xArr[tmpj] = xptr[neighborListPtr[joff + tmpj]];
-          yArr[tmpj] = yptr[neighborListPtr[joff + tmpj]];
-          zArr[tmpj] = zptr[neighborListPtr[joff + tmpj]];
-          ownedStateArr[tmpj] = ownedStatePtr[neighborListPtr[joff + tmpj]];
-          typeArr[tmpj] = typeptr2[neighborListPtr[joff + tmpj]];
-        }
-        // do omp simd with reduction of the interaction
+                    for (size_t tmpj = 0; tmpj < vecsize; tmpj++) {
+                        xArr[tmpj] = xptr[neighborListPtr[joff + tmpj]];
+                        yArr[tmpj] = yptr[neighborListPtr[joff + tmpj]];
+                        zArr[tmpj] = zptr[neighborListPtr[joff + tmpj]];
+                        ownedStateArr[tmpj] = ownedStatePtr[neighborListPtr[joff + tmpj]];
+                        typeArr[tmpj] = typeptr[neighborListPtr[joff + tmpj]];
+                    }
+                    // do omp simd with reduction of the interaction
 #pragma omp simd reduction(+ : fxacc, fyacc, fzacc, upotSum, virialSumXX, virialSumYY, virialSumZZ, virialSumXY, virialSumXZ, virialSumYZ) safelen(vecsize)
-        for (size_t j = 0; j < vecsize; j++) {
-          if (!doesInteract(typetmp[j], typeArr[j]))
-            continue;
+                    for (size_t j = 0; j < vecsize; j++) {
+                        if(!doesInteract(typetmp[j], typeArr[j])) continue;
+                        if constexpr (useMixing) {
+                            sigmasquare = sigmaSquares[j];
+                            epsilon24 = epsilon24s[j];
+                            if constexpr (applyShift) {
+                                shift6 = shift6s[j];
+                            }
+                        }
+                        // const size_t j = currentList[jNeighIndex];
 
-          if constexpr (useMixing) {
-            sigmasquare = sigmaSquares[j];
-            epsilon24 = epsilon24s[j];
-            if constexpr (applyShift) {
-              shift6 = shift6s[j];
-            }
-          }
-          // const size_t j = currentList[jNeighIndex];
+                        const auto ownedStateJ = ownedStateArr[j];
 
-          const auto ownedStateJ = ownedStateArr[j];
+                        const SoAFloatPrecision drx = xtmp[j] - xArr[j];
+                        const SoAFloatPrecision dry = ytmp[j] - yArr[j];
+                        const SoAFloatPrecision drz = ztmp[j] - zArr[j];
 
-          const SoAFloatPrecision drx = xtmp[j] - xArr[j];
-          const SoAFloatPrecision dry = ytmp[j] - yArr[j];
-          const SoAFloatPrecision drz = ztmp[j] - zArr[j];
+                        const SoAFloatPrecision drx2 = drx * drx;
+                        const SoAFloatPrecision dry2 = dry * dry;
+                        const SoAFloatPrecision drz2 = drz * drz;
 
-          const SoAFloatPrecision drx2 = drx * drx;
-          const SoAFloatPrecision dry2 = dry * dry;
-          const SoAFloatPrecision drz2 = drz * drz;
+                        const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
 
-          const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
+                        // Mask away if distance is too large or any particle is a dummy.
+                        // Particle ownedStateI was already checked previously.
+                        const bool mask = dr2 <= cutoffsquare and ownedStateJ != OwnershipState::dummy;
 
-          // Mask away if distance is too large or any particle is a dummy.
-          // Particle ownedStateI was already checked previously.
-          const bool mask =
-              dr2 <= cutoffsquare and ownedStateJ != OwnershipState::dummy;
+                        const SoAFloatPrecision invdr2 = 1. / dr2;
+                        const SoAFloatPrecision lj2 = sigmasquare * invdr2;
+                        const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
+                        const SoAFloatPrecision lj12 = lj6 * lj6;
+                        const SoAFloatPrecision lj12m6 = lj12 - lj6;
+                        const SoAFloatPrecision fac = mask ? epsilon24 * (lj12 + lj12m6) * invdr2 : 0.;
 
-          const SoAFloatPrecision invdr2 = 1. / dr2;
-          const SoAFloatPrecision lj2 = sigmasquare * invdr2;
-          const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
-          const SoAFloatPrecision lj12 = lj6 * lj6;
-          const SoAFloatPrecision lj12m6 = lj12 - lj6;
-          const SoAFloatPrecision fac =
-              mask ? epsilon24 * (lj12 + lj12m6) * invdr2 : 0.;
+                        const SoAFloatPrecision fx = drx * fac;
+                        const SoAFloatPrecision fy = dry * fac;
+                        const SoAFloatPrecision fz = drz * fac;
 
-          const SoAFloatPrecision fx = drx * fac;
-          const SoAFloatPrecision fy = dry * fac;
-          const SoAFloatPrecision fz = drz * fac;
+                        fxacc += fx;
+                        fyacc += fy;
+                        fzacc += fz;
+                        if (newton3) {
+                            fxArr[j] = fx;
+                            fyArr[j] = fy;
+                            fzArr[j] = fz;
+                        }
+                        if (calculateGlobals) {
+                            SoAFloatPrecision virialxx = drx * fx;
+                            SoAFloatPrecision virialyy = dry * fy;
+                            SoAFloatPrecision virialzz = drz * fz;
+                            SoAFloatPrecision virialxy = drx * fy;
+                            SoAFloatPrecision virialxz = drx * fz;
+                            SoAFloatPrecision virialyz = dry * fz;
+                            SoAFloatPrecision upot = mask ? (epsilon24 * lj12m6 + shift6) : 0.;
 
-          fxacc += fx;
-          fyacc += fy;
-          fzacc += fz;
-          if (newton3) {
-            fxArr[j] = fx;
-            fyArr[j] = fy;
-            fzArr[j] = fz;
-          }
-          if (calculateGlobals) {
-            SoAFloatPrecision virialxx = drx * fx;
-            SoAFloatPrecision virialyy = dry * fy;
-            SoAFloatPrecision virialzz = drz * fz;
-            SoAFloatPrecision virialxy = drx * fy;
-            SoAFloatPrecision virialxz = drx * fz;
-            SoAFloatPrecision virialyz = dry * fz;
-            SoAFloatPrecision upot = mask ? (epsilon24 * lj12m6 + shift6) : 0.;
-
-            SoAFloatPrecision energyFactor =
-                (ownedStateI == OwnershipState::owned ? 1. : 0.);
-            if constexpr (newton3) {
-              energyFactor += (ownedStateJ == OwnershipState::owned ? 1. : 0.);
-            }
-            upotSum += upot * energyFactor;
-            virialSumXX += virialxx * energyFactor;
-            virialSumYY += virialyy * energyFactor;
-            virialSumZZ += virialzz * energyFactor;
-            virialSumXY += virialxy * energyFactor;
-            virialSumXZ += virialxz * energyFactor;
-            virialSumYZ += virialyz * energyFactor;
-          }
-        }
-        // scatter the forces to where they belong, this is only needed for
-        // newton3
-        if (newton3) {
+                            SoAFloatPrecision energyFactor = (ownedStateI == OwnershipState::owned ? 1. : 0.);
+                            if constexpr (newton3) {
+                                energyFactor += (ownedStateJ == OwnershipState::owned ? 1. : 0.);
+                            }
+                            upotSum += upot * energyFactor;
+                            virialSumXX += virialxx * energyFactor;
+                            virialSumYY += virialyy * energyFactor;
+                            virialSumZZ += virialzz * energyFactor;
+                            virialSumXY += virialxy * energyFactor;
+                            virialSumXZ += virialxz * energyFactor;
+                            virialSumYZ += virialyz * energyFactor;
+                        }
+                    }
+                    // scatter the forces to where they belong, this is only needed for newton3
+                    if (newton3) {
 #pragma omp simd safelen(vecsize)
-          for (size_t tmpj = 0; tmpj < vecsize; tmpj++) {
-            const size_t j = neighborListPtr[joff + tmpj];
-            fxptr[j] -= fxArr[tmpj];
-            fyptr[j] -= fyArr[tmpj];
-            fzptr[j] -= fzArr[tmpj];
-          }
+                        for (size_t tmpj = 0; tmpj < vecsize; tmpj++) {
+                            const size_t j = neighborListPtr[joff + tmpj];
+                            fxptr[j] -= fxArr[tmpj];
+                            fyptr[j] -= fyArr[tmpj];
+                            fzptr[j] -= fzArr[tmpj];
+                        }
+                    }
+                }
+            }
+            // this loop goes over the remainder and uses no optimizations
+            for (size_t jNeighIndex = joff; jNeighIndex < neighborListSize; ++jNeighIndex) {
+                size_t j = neighborList[jNeighIndex];
+                if (indexFirst == j) continue;
+                if(!doesInteract(typeptr[indexFirst], typeptr[j])) continue;
+                if constexpr (useMixing) {
+                    sigmasquare = _PPLibrary->mixingSigmaSquare(typeptr[indexFirst], typeptr[j]);
+                    epsilon24 = _PPLibrary->mixing24Epsilon(typeptr[indexFirst], typeptr[j]);
+                    if constexpr (applyShift) {
+                        shift6 = _PPLibrary->mixingShift6(typeptr[indexFirst], typeptr[j]);
+                    }
+                }
+
+                const auto ownedStateJ = ownedStatePtr[j];
+                if (ownedStateJ == OwnershipState::dummy) {
+                    continue;
+                }
+
+                const SoAFloatPrecision drx = xptr[indexFirst] - xptr[j];
+                const SoAFloatPrecision dry = yptr[indexFirst] - yptr[j];
+                const SoAFloatPrecision drz = zptr[indexFirst] - zptr[j];
+
+                const SoAFloatPrecision drx2 = drx * drx;
+                const SoAFloatPrecision dry2 = dry * dry;
+                const SoAFloatPrecision drz2 = drz * drz;
+
+                const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
+
+                if (dr2 > cutoffsquare) {
+                    continue;
+                }
+
+                const SoAFloatPrecision invdr2 = 1. / dr2;
+                const SoAFloatPrecision lj2 = sigmasquare * invdr2;
+                const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
+                const SoAFloatPrecision lj12 = lj6 * lj6;
+                const SoAFloatPrecision lj12m6 = lj12 - lj6;
+                const SoAFloatPrecision fac = epsilon24 * (lj12 + lj12m6) * invdr2;
+
+                const SoAFloatPrecision fx = drx * fac;
+                const SoAFloatPrecision fy = dry * fac;
+                const SoAFloatPrecision fz = drz * fac;
+
+                fxacc += fx;
+                fyacc += fy;
+                fzacc += fz;
+                if (newton3) {
+                    fxptr[j] -= fx;
+                    fyptr[j] -= fy;
+                    fzptr[j] -= fz;
+                }
+                if (calculateGlobals) {
+                    SoAFloatPrecision virialxx = drx * fx;
+                    SoAFloatPrecision virialyy = dry * fy;
+                    SoAFloatPrecision virialzz = drz * fz;
+                    SoAFloatPrecision virialxy = drx * fy;
+                    SoAFloatPrecision virialxz = drx * fz;
+                    SoAFloatPrecision virialyz = dry * fz;
+                    SoAFloatPrecision upot = (epsilon24 * lj12m6 + shift6);
+
+                    SoAFloatPrecision energyFactor = (ownedStateI == OwnershipState::owned ? 1. : 0.);
+                    if constexpr (newton3) {
+                        energyFactor += (ownedStateJ == OwnershipState::owned ? 1. : 0.);
+                    }
+                    upotSum += upot * energyFactor;
+                    virialSumXX += virialxx * energyFactor;
+                    virialSumYY += virialyy * energyFactor;
+                    virialSumZZ += virialzz * energyFactor;
+                    virialSumXY += virialxy * energyFactor;
+                    virialSumXZ += virialxz * energyFactor;
+                    virialSumYZ += virialyz * energyFactor;
+                }
+            }
+
+            if (fxacc != 0 or fyacc != 0 or fzacc != 0) {
+                fxptr[indexFirst] += fxacc;
+                fyptr[indexFirst] += fyacc;
+                fzptr[indexFirst] += fzacc;
+            }
+
+            if (calculateGlobals) {
+                const int threadnum = autopas_get_thread_num();
+
+                SoAFloatPrecision energyMul = newton3 ? 0.5 : 1.;
+
+                _aosThreadData[threadnum].upotSum += upotSum * energyMul;
+                _aosThreadData[threadnum].virialSum[0] += virialSumXX * energyMul;
+                _aosThreadData[threadnum].virialSum[1] += virialSumYY * energyMul;
+                _aosThreadData[threadnum].virialSum[2] += virialSumZZ * energyMul;
+                _aosThreadData[threadnum].virialSum[3] += virialSumXX * energyMul;
+                _aosThreadData[threadnum].virialSum[4] += virialSumYY * energyMul;
+                _aosThreadData[threadnum].virialSum[5] += virialSumZZ * energyMul;
+            }
         }
-      }
-    }
-    // this loop goes over the remainder and uses no optimizations
-    for (size_t jNeighIndex = joff; jNeighIndex < neighborListSize;
-         ++jNeighIndex) {
-      size_t j = neighborList[jNeighIndex];
-      if (indexFirst == j)
-        continue;
-      if (!doesInteract(typeptr1[indexFirst], typeptr2[j]))
-        continue;
-      if constexpr (useMixing) {
-        sigmasquare =
-            _PPLibrary->mixingSigmaSquare(typeptr1[indexFirst], typeptr2[j]);
-        epsilon24 =
-            _PPLibrary->mixing24Epsilon(typeptr1[indexFirst], typeptr2[j]);
-        if constexpr (applyShift) {
-          shift6 = _PPLibrary->mixingShift6(typeptr1[indexFirst], typeptr2[j]);
+
+        inline int doesInteract(size_t i, size_t j) const{
+            return _interactingTypes[i - 1][j - 1];
         }
-      }
 
-      const auto ownedStateJ = ownedStatePtr[j];
-      if (ownedStateJ == OwnershipState::dummy) {
-        continue;
-      }
+        /**
+         * This class stores internal data of each thread, make sure that this data has proper size, i.e. k*64 Bytes!
+         */
+        class AoSThreadData {
+        public:
+            AoSThreadData() : virialSum{0., 0., 0., 0., 0., 0.}, upotSum{0.}, __remainingTo64{} {}
+            void setZero() {
+                virialSum = {0., 0., 0., 0., 0., 0.};
+                upotSum = 0.;
+            }
 
-      const SoAFloatPrecision drx = xptr[indexFirst] - xptr[j];
-      const SoAFloatPrecision dry = yptr[indexFirst] - yptr[j];
-      const SoAFloatPrecision drz = zptr[indexFirst] - zptr[j];
+            // variables
+            std::array<double, 6> virialSum;
+            double upotSum;
 
-      const SoAFloatPrecision drx2 = drx * drx;
-      const SoAFloatPrecision dry2 = dry * dry;
-      const SoAFloatPrecision drz2 = drz * drz;
+        private:
+            // dummy parameter to get the right size (64 bytes)
+            double __remainingTo64[(64 - 7 * sizeof(double)) / sizeof(double)];
+        };
+        // make sure of the size of AoSThreadData
+        static_assert(sizeof(AoSThreadData) % 64 == 0, "AoSThreadData has wrong size");
 
-      const SoAFloatPrecision dr2 = drx2 + dry2 + drz2;
+        const double _cutoffsquare;
+        // not const because they might be reset through PPL
+        double _epsilon24, _sigmasquare, _shift6 = 0;
 
-      if (dr2 > cutoffsquare)
-        continue;
+        ParticlePropertiesLibrary<SoAFloatPrecision, size_t> *_PPLibrary = nullptr;
 
-      const SoAFloatPrecision invdr2 = 1. / dr2;
-      const SoAFloatPrecision lj2 = sigmasquare * invdr2;
-      const SoAFloatPrecision lj6 = lj2 * lj2 * lj2;
-      const SoAFloatPrecision lj12 = lj6 * lj6;
-      const SoAFloatPrecision lj12m6 = lj12 - lj6;
-      const SoAFloatPrecision fac = epsilon24 * (lj12 + lj12m6) * invdr2;
+        // sum of the potential energy, only calculated if calculateGlobals is true
+        double _upotSum;
 
-      const SoAFloatPrecision fx = drx * fac;
-      const SoAFloatPrecision fy = dry * fac;
-      const SoAFloatPrecision fz = drz * fac;
+        // sum of the virial, only calculated if calculateGlobals is true
+        std::array<double, 6> _virialSum;
 
-      fxacc += fx;
-      fyacc += fy;
-      fzacc += fz;
-      if (newton3) {
-        fxptr[j] -= fx;
-        fyptr[j] -= fy;
-        fzptr[j] -= fz;
-      }
-      if (calculateGlobals) {
-        SoAFloatPrecision virialxx = drx * fx;
-        SoAFloatPrecision virialyy = dry * fy;
-        SoAFloatPrecision virialzz = drz * fz;
-        SoAFloatPrecision virialxy = drx * fy;
-        SoAFloatPrecision virialxz = drx * fz;
-        SoAFloatPrecision virialyz = dry * fz;
-        SoAFloatPrecision upot = (epsilon24 * lj12m6 + shift6);
+        // thread buffer for aos
+        std::vector<AoSThreadData> _aosThreadData;
 
-        SoAFloatPrecision energyFactor =
-            (ownedStateI == OwnershipState::owned ? 1. : 0.);
-        if constexpr (newton3) {
-          energyFactor += (ownedStateJ == OwnershipState::owned ? 1. : 0.);
-        }
-        upotSum += upot * energyFactor;
-        virialSumXX += virialxx * energyFactor;
-        virialSumYY += virialyy * energyFactor;
-        virialSumZZ += virialzz * energyFactor;
-        virialSumXY += virialxy * energyFactor;
-        virialSumXZ += virialxz * energyFactor;
-        virialSumYZ += virialyz * energyFactor;
-      }
-    }
+        // defines whether or whether not the global values are already preprocessed
+        bool _postProcessed;
 
-    if (fxacc != 0 or fyacc != 0 or fzacc != 0) {
-      fxptr[indexFirst] += fxacc;
-      fyptr[indexFirst] += fyacc;
-      fzptr[indexFirst] += fzacc;
-    }
-
-    if (calculateGlobals) {
-      const int threadnum = autopas_get_thread_num();
-
-      SoAFloatPrecision energyMul = newton3 ? 0.5 : 1.;
-
-      _aosThreadData[threadnum].upotSum += upotSum * energyMul;
-      _aosThreadData[threadnum].virialSum[0] += virialSumXX * energyMul;
-      _aosThreadData[threadnum].virialSum[1] += virialSumYY * energyMul;
-      _aosThreadData[threadnum].virialSum[2] += virialSumZZ * energyMul;
-      _aosThreadData[threadnum].virialSum[3] += virialSumXY * energyMul;
-      _aosThreadData[threadnum].virialSum[4] += virialSumXZ * energyMul;
-      _aosThreadData[threadnum].virialSum[5] += virialSumYZ * energyMul;
-    }
-  }
-
-  inline int doesInteract(size_t i, size_t j) const {
-    return _interactingTypes[i - 1][j - 1] ;
-  }
-
-  /**
-   * This class stores internal data of each thread, make sure that this data
-   * has proper size, i.e. k*64 Bytes!
-   */
-  class AoSThreadData {
-  public:
-    AoSThreadData()
-        : virialSum{0., 0., 0., 0., 0., 0.}, upotSum{0.}, __remainingTo64{} {}
-    void setZero() {
-      virialSum = {0., 0., 0., 0., 0., 0.};
-      upotSum = 0.;
-    }
-
-    // variables
-    std::array<double, 6> virialSum;
-    double upotSum;
-
-  private:
-    // dummy parameter to get the right size (64 bytes)
-    double __remainingTo64[(64 - 7 * sizeof(double)) / sizeof(double)];
-  };
-  // make sure of the size of AoSThreadData
-  static_assert(sizeof(AoSThreadData) % 64 == 0,
-                "AoSThreadData has wrong size");
-
-  const double _cutoffsquare;
-  // not const because they might be reset through PPL
-  double _epsilon24, _sigmasquare, _shift6 = 0;
-
-  ParticlePropertiesLibrary<SoAFloatPrecision, size_t> *_PPLibrary = nullptr;
-
-  // sum of the potential energy, only calculated if calculateGlobals is true
-  double _upotSum;
-
-  // sum of the virial, only calculated if calculateGlobals is true
-  std::array<double, 6> _virialSum;
-
-  // thread buffer for aos
-  std::vector<AoSThreadData> _aosThreadData;
-
-  // defines whether or whether not the global values are already preprocessed
-  bool _postProcessed;
-
-  // Type map
-  interactingTypes_t _interactingTypes;
-
-#if defined(AUTOPAS_CUDA)
-  using CudaWrapperType = typename std::conditional<
-      calculateGlobals, autopas::LJFunctorCudaGlobalsWrapper<SoAFloatPrecision>,
-      autopas::LJFunctorCudaWrapper<SoAFloatPrecision>>::type;
-  // contains wrapper functions for cuda calls
-  CudaWrapperType _cudawrapper;
-
-  // contains device globals
-  autopas::utils::CudaDeviceVector<SoAFloatPrecision> _cudaGlobals;
-
-#endif
-
-}; // class LJFunctor
-} // namespace LAMMPS_NS
+        // Type map
+        interactingTypes_t _interactingTypes;
+    };
+}  // namespace

--- a/src/USER-AUTOPAS/autopas_lj_functor_avx.h
+++ b/src/USER-AUTOPAS/autopas_lj_functor_avx.h
@@ -1,159 +1,124 @@
 /**
- * @file autopas_lj_functor_avx.h
+ * @file LJFunctorAVX.h
+ *
+ * @date 17 Jan 2018
  * @author F. Gratl
- * @date 21.09.20
  */
-
 #pragma once
-
+#ifndef __AVX__
+#pragma message "Requested to compile LJFunctorAVX but AVX is not available!"
+#else
 #include <immintrin.h>
+#endif
 
 #include <array>
-#include <autopas/particles/OwnershipState.h>
 
-#include "autopas/iterators/SingleCellIterator.h"
 #include "autopas/molecularDynamics/ParticlePropertiesLibrary.h"
+#include "autopas/iterators/SingleCellIterator.h"
 #include "autopas/pairwiseFunctors/Functor.h"
+#include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/AlignedAllocator.h"
 #include "autopas/utils/ArrayMath.h"
-#include "autopas/utils/StaticSelectorMacros.h"
+#include "autopas/utils/StaticBoolSelector.h"
 #include "autopas/utils/WrapOpenMP.h"
 #include "autopas/utils/inBox.h"
 
-namespace LAMMPS_NS {
+namespace autopas {
 
 /**
- * A functor to handle lennard-jones interactions between two particles
- * (molecules). This functor assumes that duplicated calculations are always
- * happening, which is characteristic for a Full-Shell scheme. This Version is
- * implemented using AVX intrinsics.
+ * A functor to handle lennard-jones interactions between two particles (molecules).
+ * This functor assumes that duplicated calculations are always happening, which is characteristic for a Full-Shell
+ * scheme.
+ * This Version is implemented using AVX intrinsics.
  * @tparam Particle The type of particle.
  * @tparam ParticleCell The type of particlecell.
  * @tparam applyShift Switch for the lj potential to be truncated shifted.
- * @tparam useMixing Switch for the functor to be used with multiple particle
- * types. If set to false, _epsilon and _sigma need to be set and the
- * constructor with PPL can be omitted.
- * @tparam useNewton3 Switch for the functor to support newton3 on, off or both.
- * See FunctorN3Modes for possible values.
- * @tparam calculateGlobals Defines whether the global values are to be
- * calculated (energy, virial).
- * @tparam relevantForTuning Whether or not the auto-tuner should consider this
- * functor.
+ * @tparam useMixing Switch for the functor to be used with multiple particle types.
+ * If set to false, _epsilon and _sigma need to be set and the constructor with PPL can be omitted.
+ * @tparam useNewton3 Switch for the functor to support newton3 on, off or both. See FunctorN3Modes for possible values.
+ * @tparam calculateGlobals Defines whether the global values are to be calculated (energy, virial).
+ * @tparam relevantForTuning Whether or not the auto-tuner should consider this functor.
  */
-template <class Particle, class ParticleCell, bool applyShift = false,
-          bool useMixing = false,
-          autopas::FunctorN3Modes useNewton3 = autopas::FunctorN3Modes::Both,
-          bool calculateGlobals = false, bool relevantForTuning = true>
-class LJFunctorAVXLammps
-    : public autopas::Functor<
-          Particle, ParticleCell, typename Particle::SoAArraysType,
-          LJFunctorAVXLammps<Particle, ParticleCell, applyShift, useMixing,
-                             useNewton3, calculateGlobals, relevantForTuning>> {
+template <class Particle, bool applyShift = false, bool useMixing = false,
+          FunctorN3Modes useNewton3 = FunctorN3Modes::Both, bool calculateGlobals = false,
+          bool relevantForTuning = true>
+class LJFunctorAVX
+    : public Functor<Particle,
+                     LJFunctorAVX<Particle, applyShift, useMixing, useNewton3, calculateGlobals, relevantForTuning>> {
   using SoAArraysType = typename Particle::SoAArraysType;
-  using SoAFloatPrecision = typename Particle::ParticleSoAFloatPrecision;
 
-  using interactingTypes_t = std::vector<std::vector<int>>;
-
-public:
+ public:
   /**
    * Deleted default constructor
    */
-  LJFunctorAVXLammps() = delete;
+  LJFunctorAVX() = delete;
 
-private:
+ private:
   /**
    * Internal, actual constructor.
    * @param cutoff
-   * @param dummy unused, only there to make the signature different from the
-   * public constructor.
+   * @note param dummy unused, only there to make the signature different from the public constructor.
    */
-  explicit LJFunctorAVXLammps(double cutoff,
-                              interactingTypes_t interactingTypes,
-                              void * /*dummy*/)
+  explicit LJFunctorAVX(double cutoff, void * /*dummy*/)
 #ifdef __AVX__
-      : autopas::Functor<Particle, ParticleCell, SoAArraysType,
-                         LJFunctorAVXLammps<
-                             Particle, ParticleCell, applyShift, useMixing,
-                             useNewton3, calculateGlobals, relevantForTuning>>(
-            cutoff),
+      : Functor<Particle,
+                LJFunctorAVX<Particle, applyShift, useMixing, useNewton3, calculateGlobals, relevantForTuning>>(cutoff),
         _cutoffsquare{_mm256_set1_pd(cutoff * cutoff)},
-        _cutoffsquareAoS(cutoff * cutoff), _upotSum{0.}, _virialSum{0., 0., 0.},
-        _aosThreadData(), _postProcessed{false}, _interactingTypes{std::move(
-                                                     interactingTypes)} {
-    using namespace autopas;
+        _cutoffsquareAoS(cutoff * cutoff),
+        _upotSum{0.},
+        _virialSum{0., 0., 0.},
+        _aosThreadData(),
+        _postProcessed{false} {
     if (calculateGlobals) {
       _aosThreadData.resize(autopas_get_max_threads());
     }
   }
 #else
-      : Functor<Particle, ParticleCell, SoAArraysType,
-                LJFunctorAVXLammps<Particle, ParticleCell, applyShift,
-                                   useMixing, useNewton3, calculateGlobals,
-                                   relevantForTuning>>(cutoff) {
-    autopas::utils::ExceptionHandler::exception(
-        "AutoPas was compiled without AVX support!");
+      : Functor<Particle,
+                LJFunctorAVX<Particle, applyShift, useMixing, useNewton3, calculateGlobals, relevantForTuning>>(
+            cutoff) {
+    utils::ExceptionHandler::exception("AutoPas was compiled without AVX support!");
   }
 #endif
-public:
+ public:
   /**
-   * Constructor for Functor with mixing disabled. When using this functor it is
-   * necessary to call setParticleProperties() to set internal constants because
-   * it does not use a particle properties library.
+   * Constructor for Functor with mixing disabled. When using this functor it is necessary to call
+   * setParticleProperties() to set internal constants because it does not use a particle properties library.
    *
    * @note Only to be used with mixing == false.
    *
    * @param cutoff
    */
-  explicit LJFunctorAVXLammps(double cutoff,
-                              const interactingTypes_t &interactingTypes)
-      : LJFunctorAVXLammps(cutoff, interactingTypes, nullptr) {
+  explicit LJFunctorAVX(double cutoff) : LJFunctorAVX(cutoff, nullptr) {
     static_assert(not useMixing,
-                  "Mixing without a ParticlePropertiesLibrary is not possible! "
-                  "Use a different constructor or set "
+                  "Mixing without a ParticlePropertiesLibrary is not possible! Use a different constructor or set "
                   "mixing to false.");
   }
 
   /**
-   * Constructor for Functor with mixing active. This functor takes a
-   * ParticlePropertiesLibrary to look up (mixed) properties like sigma, epsilon
-   * and shift.
+   * Constructor for Functor with mixing active. This functor takes a ParticlePropertiesLibrary to look up (mixed)
+   * properties like sigma, epsilon and shift.
    * @param cutoff
    * @param particlePropertiesLibrary
    */
-  explicit LJFunctorAVXLammps(
-      double cutoff, const interactingTypes_t &interactingTypes,
-      ParticlePropertiesLibrary<double, size_t> &particlePropertiesLibrary)
-      : LJFunctorAVXLammps(cutoff, interactingTypes, nullptr) {
+  explicit LJFunctorAVX(double cutoff, ParticlePropertiesLibrary<double, size_t> &particlePropertiesLibrary)
+      : LJFunctorAVX(cutoff, nullptr) {
     static_assert(useMixing,
-                  "Not using Mixing but using a ParticlePropertiesLibrary is "
-                  "not allowed! Use a different constructor "
+                  "Not using Mixing but using a ParticlePropertiesLibrary is not allowed! Use a different constructor "
                   "or set mixing to true.");
     _PPLibrary = &particlePropertiesLibrary;
   }
 
-  bool isRelevantForTuning() override { return relevantForTuning; }
+  bool isRelevantForTuning() final { return relevantForTuning; }
 
-  bool allowsNewton3() override {
-    return useNewton3 == autopas::FunctorN3Modes::Newton3Only or
-           useNewton3 == autopas::FunctorN3Modes::Both;
+  bool allowsNewton3() final { return useNewton3 == FunctorN3Modes::Newton3Only or useNewton3 == FunctorN3Modes::Both; }
+
+  bool allowsNonNewton3() final {
+    return useNewton3 == FunctorN3Modes::Newton3Off or useNewton3 == FunctorN3Modes::Both;
   }
 
-  bool allowsNonNewton3() override {
-    return useNewton3 == autopas::FunctorN3Modes::Newton3Off or
-           useNewton3 == autopas::FunctorN3Modes::Both;
-  }
-
-  bool isAppropriateClusterSize(
-      unsigned int clusterSize,
-      autopas::DataLayoutOption::Value dataLayout) const override {
-    return dataLayout ==
-           autopas::DataLayoutOption::aos; // LJFunctorAVXLammps does only
-                                           // support clusters via aos.
-  }
-
-  void AoSFunctor(Particle &i, Particle &j, bool newton3) override {
-    if (not doesInteract(i.getTypeId(), j.getTypeId()) or i.isDummy() or
-        j.isDummy()) {
+  void AoSFunctor(Particle &i, Particle &j, bool newton3) final {
+    if (i.isDummy() or j.isDummy()) {
       return;
     }
     auto sigmasquare = _sigmaSquareAoS;
@@ -166,8 +131,8 @@ public:
         shift6 = _PPLibrary->mixingShift6(i.getTypeId(), j.getTypeId());
       }
     }
-    auto dr = autopas::utils::ArrayMath::sub(i.getR(), j.getR());
-    double dr2 = autopas::utils::ArrayMath::dot(dr, dr);
+    auto dr = utils::ArrayMath::sub(i.getR(), j.getR());
+    double dr2 = utils::ArrayMath::dot(dr, dr);
 
     if (dr2 > _cutoffsquareAoS) {
       return;
@@ -179,47 +144,39 @@ public:
     double lj12 = lj6 * lj6;
     double lj12m6 = lj12 - lj6;
     double fac = epsilon24 * (lj12 + lj12m6) * invdr2;
-    auto f = autopas::utils::ArrayMath::mulScalar(dr, fac);
+    auto f = utils::ArrayMath::mulScalar(dr, fac);
     i.addF(f);
     if (newton3) {
       // only if we use newton 3 here, we want to
       j.subF(f);
     }
     if (calculateGlobals) {
-      std::array<double, 6> dr_virial = {dr[0], dr[1], dr[2],
-                                         dr[0], dr[0], dr[1]};
-      std::array<double, 6> f_virial = {f[0], f[1], f[2], f[1], f[2], f[2]};
-      auto virial = autopas::utils::ArrayMath::mul(dr_virial, f_virial);
+      auto virial = utils::ArrayMath::mul(dr, f);
       double upot = epsilon24 * lj12m6 + shift6;
 
-      const int threadnum = autopas::autopas_get_thread_num();
+      const int threadnum = autopas_get_thread_num();
       // for non-newton3 the division is in the post-processing step.
       if (newton3) {
         upot *= 0.5;
-        virial = autopas::utils::ArrayMath::mulScalar(virial, (double)0.5);
+        virial = utils::ArrayMath::mulScalar(virial, (double)0.5);
       }
       if (i.isOwned()) {
         _aosThreadData[threadnum].upotSum += upot;
-        _aosThreadData[threadnum].virialSum = autopas::utils::ArrayMath::add(
-            _aosThreadData[threadnum].virialSum, virial);
+        _aosThreadData[threadnum].virialSum = utils::ArrayMath::add(_aosThreadData[threadnum].virialSum, virial);
       }
-      // for non-newton3 the second particle will be considered in a separate
-      // calculation
+      // for non-newton3 the second particle will be considered in a separate calculation
       if (newton3 and j.isOwned()) {
         _aosThreadData[threadnum].upotSum += upot;
-        _aosThreadData[threadnum].virialSum = autopas::utils::ArrayMath::add(
-            _aosThreadData[threadnum].virialSum, virial);
+        _aosThreadData[threadnum].virialSum = utils::ArrayMath::add(_aosThreadData[threadnum].virialSum, virial);
       }
     }
   }
 
   /**
-   * @copydoc Functor::SoAFunctorSingle(SoAView<SoAArraysType> soa, bool
-   * newton3) This functor ignores the newton3 value, as we do not expect any
-   * benefit from disabling newton3.
+   * @copydoc Functor::SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3)
+   * This functor ignores the newton3 value, as we do not expect any benefit from disabling newton3.
    */
-  void SoAFunctorSingle(autopas::SoAView<SoAArraysType> soa,
-                        bool newton3) override {
+  void SoAFunctorSingle(SoAView<SoAArraysType> soa, bool newton3) final {
     if (newton3) {
       SoAFunctorSingleImpl<true>(soa);
     } else {
@@ -232,9 +189,7 @@ public:
    * @copydoc Functor::SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, bool newton3)
    */
   // clang-format on
-  void SoAFunctorPair(autopas::SoAView<SoAArraysType> soa1,
-                      autopas::SoAView<SoAArraysType> soa2,
-                      const bool newton3) override {
+  void SoAFunctorPair(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2, const bool newton3) final {
     if (newton3) {
       SoAFunctorPairImpl<true>(soa1, soa2);
     } else {
@@ -242,64 +197,47 @@ public:
     }
   }
 
-private:
+ private:
   /**
-   * Templatized version of SoAFunctorSingle actually doing what the latter
-   * should.
+   * Templatized version of SoAFunctorSingle actually doing what the latter should.
    * @tparam newton3
    * @param soa
    */
   template <bool newton3>
-  void SoAFunctorSingleImpl(autopas::SoAView<SoAArraysType> soa) {
+  void SoAFunctorSingleImpl(SoAView<SoAArraysType> soa) {
 #ifdef __AVX__
-    if (soa.getNumParticles() == 0)
-      return;
+    if (soa.getNumberOfParticles() == 0) return;
 
-    const auto *const __restrict__ xptr =
-        soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict__ yptr =
-        soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict__ zptr =
-        soa.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
-    const auto *const __restrict__ ownedStatePtr =
-        soa.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
 
-    auto *const __restrict__ fxptr =
-        soa.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict__ fyptr =
-        soa.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict__ fzptr =
-        soa.template begin<Particle::AttributeNames::forceZ>();
+    auto *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
+    auto *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
+    auto *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
 
-    const auto *const __restrict__ typeIDptr =
-        soa.template begin<Particle::AttributeNames::typeId>();
+    const auto *const __restrict typeIDptr = soa.template begin<Particle::AttributeNames::typeId>();
 
-    __m256d virialSumXX = _mm256_setzero_pd();
-    __m256d virialSumYY = _mm256_setzero_pd();
-    __m256d virialSumZZ = _mm256_setzero_pd();
-    __m256d virialSumXY = _mm256_setzero_pd();
-    __m256d virialSumXZ = _mm256_setzero_pd();
-    __m256d virialSumYZ = _mm256_setzero_pd();
+    __m256d virialSumX = _mm256_setzero_pd();
+    __m256d virialSumY = _mm256_setzero_pd();
+    __m256d virialSumZ = _mm256_setzero_pd();
     __m256d upotSum = _mm256_setzero_pd();
 
     // reverse outer loop s.th. inner loop always beginns at aligned array start
     // typecast to detect underflow
-    for (size_t i = soa.getNumParticles() - 1; (long)i >= 0; --i) {
-      if (ownedStatePtr[i] == autopas::OwnershipState::dummy) {
+    for (size_t i = soa.getNumberOfParticles() - 1; (long)i >= 0; --i) {
+      if (ownedStatePtr[i] == OwnershipState::dummy) {
         // If the i-th particle is a dummy, skip this loop iteration.
         continue;
       }
 
-      static_assert(
-          std::is_same_v<std::underlying_type_t<autopas::OwnershipState>,
-                         int64_t>,
-          "autopas::OwnershipStates underlying type should be int64_t!");
-      // ownedStatePtr contains int64_t, so we broadcast these to make an
-      // __m256i. _mm256_set1_epi64x broadcasts a 64-bit integer, we use this
-      // instruction to have 4 values!
-      __m256i ownedStateI =
-          _mm256_set1_epi64x(static_cast<int64_t>(ownedStatePtr[i]));
+      static_assert(std::is_same_v<std::underlying_type_t<OwnershipState>, int64_t>,
+                    "OwnershipStates underlying type should be int64_t!");
+      // ownedStatePtr contains int64_t, so we broadcast these to make an __m256i.
+      // _mm256_set1_epi64x broadcasts a 64-bit integer, we use this instruction to have 4 values!
+      __m256i ownedStateI = _mm256_set1_epi64x(static_cast<int64_t>(ownedStatePtr[i]));
 
       __m256d fxacc = _mm256_setzero_pd();
       __m256d fyacc = _mm256_setzero_pd();
@@ -314,23 +252,17 @@ private:
       // If b is a power of 2 the following holds:
       // a & ~(b -1) == a - (a mod b)
       for (; j < (i & ~(vecLength - 1)); j += 4) {
-        SoAKernel<true, false>(
-            j, ownedStateI, reinterpret_cast<const int64_t *>(ownedStatePtr),
-            x1, y1, z1, xptr, yptr, zptr, fxptr, fyptr, fzptr, &typeIDptr[i],
-            typeIDptr, fxacc, fyacc, fzacc, &virialSumXX, &virialSumYY,
-            &virialSumZZ, &virialSumXY, &virialSumXZ, &virialSumYZ, &upotSum,
-            0);
+        SoAKernel<true, false>(j, ownedStateI, reinterpret_cast<const int64_t *>(ownedStatePtr), x1, y1, z1, xptr, yptr,
+                               zptr, fxptr, fyptr, fzptr, &typeIDptr[i], typeIDptr, fxacc, fyacc, fzacc, &virialSumX,
+                               &virialSumY, &virialSumZ, &upotSum, 0);
       }
       // If b is a power of 2 the following holds:
       // a & (b -1) == a mod b
       const int rest = (int)(i & (vecLength - 1));
       if (rest > 0) {
-        SoAKernel<true, true>(
-            j, ownedStateI, reinterpret_cast<const int64_t *>(ownedStatePtr),
-            x1, y1, z1, xptr, yptr, zptr, fxptr, fyptr, fzptr, &typeIDptr[i],
-            typeIDptr, fxacc, fyacc, fzacc, &virialSumXX, &virialSumYY,
-            &virialSumZZ, &virialSumXY, &virialSumXZ, &virialSumYZ, &upotSum,
-            rest);
+        SoAKernel<true, true>(j, ownedStateI, reinterpret_cast<const int64_t *>(ownedStatePtr), x1, y1, z1, xptr, yptr,
+                              zptr, fxptr, fyptr, fzptr, &typeIDptr[i], typeIDptr, fxacc, fyacc, fzacc, &virialSumX,
+                              &virialSumY, &virialSumZ, &upotSum, rest);
       }
 
       // horizontally reduce fDacc to sumfD
@@ -356,89 +288,70 @@ private:
     }
 
     if constexpr (calculateGlobals) {
-      const int threadnum = autopas::autopas_get_thread_num();
+      const int threadnum = autopas_get_thread_num();
 
-      // horizontally reduce virialSum and upot
-      const auto [hSumVirialXX, hSumVirialYY] =
-          horizontallySumRegister(virialSumXX, virialSumYY);
-      const auto [hSumVirialZZ, hSumVirialXY] =
-          horizontallySumRegister(virialSumZZ, virialSumXY);
-      const auto [hSumVirialXZ, hSumVirialYZ] =
-          horizontallySumRegister(virialSumXZ, virialSumYZ);
+      // horizontally reduce virialSumX and virialSumY
+      const __m256d hSumVirialxy = _mm256_hadd_pd(virialSumX, virialSumY);
+      const __m128d hSumVirialxyLow = _mm256_extractf128_pd(hSumVirialxy, 0);
+      const __m128d hSumVirialxyHigh = _mm256_extractf128_pd(hSumVirialxy, 1);
+      const __m128d hSumVirialxyVec = _mm_add_pd(hSumVirialxyHigh, hSumVirialxyLow);
 
-      const auto [_, hSumUpot] = horizontallySumRegister(_zero, upotSum);
+      // horizontally reduce virialSumZ and upotSum
+      const __m256d hSumVirialzUpot = _mm256_hadd_pd(virialSumZ, upotSum);
+      const __m128d hSumVirialzUpotLow = _mm256_extractf128_pd(hSumVirialzUpot, 0);
+      const __m128d hSumVirialzUpotHigh = _mm256_extractf128_pd(hSumVirialzUpot, 1);
+      const __m128d hSumVirialzUpotVec = _mm_add_pd(hSumVirialzUpotHigh, hSumVirialzUpotLow);
+
+      // globals = {virialX, virialY, virialZ, uPot}
+      double globals[4];
+      _mm_store_pd(&globals[0], hSumVirialxyVec);
+      _mm_store_pd(&globals[2], hSumVirialzUpotVec);
 
       double factor = 1.;
-      // we assume newton3 to be enabled in this function call, thus we multiply
-      // by two if the value of newton3 is false, since for newton3 disabled we
-      // divide by two later on.
+      // we assume newton3 to be enabled in this function call, thus we multiply by two if the value of newton3 is
+      // false, since for newton3 disabled we divide by two later on.
       factor *= newton3 ? .5 : 1.;
-      // In case we have a non-cell-wise owned state, we have multiplied
-      // everything by two, so we divide it by 2 again.
-      _aosThreadData[threadnum].upotSum += hSumUpot * factor;
-      _aosThreadData[threadnum].virialSum[0] += hSumVirialXX * factor;
-      _aosThreadData[threadnum].virialSum[1] += hSumVirialYY * factor;
-      _aosThreadData[threadnum].virialSum[2] += hSumVirialZZ * factor;
-      _aosThreadData[threadnum].virialSum[3] += hSumVirialXY * factor;
-      _aosThreadData[threadnum].virialSum[4] += hSumVirialXZ * factor;
-      _aosThreadData[threadnum].virialSum[5] += hSumVirialYZ * factor;
+      // In case we have a non-cell-wise owned state, we have multiplied everything by two, so we divide it by 2 again.
+      _aosThreadData[threadnum].virialSum[0] += globals[0] * factor;
+      _aosThreadData[threadnum].virialSum[1] += globals[1] * factor;
+      _aosThreadData[threadnum].virialSum[2] += globals[2] * factor;
+      _aosThreadData[threadnum].upotSum += globals[3] * factor;
     }
 #endif
   }
 
   template <bool newton3>
-  void SoAFunctorPairImpl(autopas::SoAView<SoAArraysType> soa1,
-                          autopas::SoAView<SoAArraysType> soa2) {
+  void SoAFunctorPairImpl(SoAView<SoAArraysType> soa1, SoAView<SoAArraysType> soa2) {
 #ifdef __AVX__
-    if (soa1.getNumParticles() == 0 || soa2.getNumParticles() == 0)
-      return;
+    if (soa1.getNumberOfParticles() == 0 || soa2.getNumberOfParticles() == 0) return;
 
-    const auto *const __restrict__ x1ptr =
-        soa1.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict__ y1ptr =
-        soa1.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict__ z1ptr =
-        soa1.template begin<Particle::AttributeNames::posZ>();
-    const auto *const __restrict__ x2ptr =
-        soa2.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict__ y2ptr =
-        soa2.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict__ z2ptr =
-        soa2.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict x1ptr = soa1.template begin<Particle::AttributeNames::posX>();
+    const auto *const __restrict y1ptr = soa1.template begin<Particle::AttributeNames::posY>();
+    const auto *const __restrict z1ptr = soa1.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict x2ptr = soa2.template begin<Particle::AttributeNames::posX>();
+    const auto *const __restrict y2ptr = soa2.template begin<Particle::AttributeNames::posY>();
+    const auto *const __restrict z2ptr = soa2.template begin<Particle::AttributeNames::posZ>();
 
-    const auto *const __restrict__ ownedStatePtr1 =
-        soa1.template begin<Particle::AttributeNames::ownershipState>();
-    const auto *const __restrict__ ownedStatePtr2 =
-        soa2.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr1 = soa1.template begin<Particle::AttributeNames::ownershipState>();
+    const auto *const __restrict ownedStatePtr2 = soa2.template begin<Particle::AttributeNames::ownershipState>();
 
-    auto *const __restrict__ fx1ptr =
-        soa1.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict__ fy1ptr =
-        soa1.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict__ fz1ptr =
-        soa1.template begin<Particle::AttributeNames::forceZ>();
-    auto *const __restrict__ fx2ptr =
-        soa2.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict__ fy2ptr =
-        soa2.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict__ fz2ptr =
-        soa2.template begin<Particle::AttributeNames::forceZ>();
+    auto *const __restrict fx1ptr = soa1.template begin<Particle::AttributeNames::forceX>();
+    auto *const __restrict fy1ptr = soa1.template begin<Particle::AttributeNames::forceY>();
+    auto *const __restrict fz1ptr = soa1.template begin<Particle::AttributeNames::forceZ>();
+    auto *const __restrict fx2ptr = soa2.template begin<Particle::AttributeNames::forceX>();
+    auto *const __restrict fy2ptr = soa2.template begin<Particle::AttributeNames::forceY>();
+    auto *const __restrict fz2ptr = soa2.template begin<Particle::AttributeNames::forceZ>();
 
-    const auto *const __restrict__ typeID1ptr =
-        soa1.template begin<Particle::AttributeNames::typeId>();
-    const auto *const __restrict__ typeID2ptr =
-        soa2.template begin<Particle::AttributeNames::typeId>();
+    const auto *const __restrict typeID1ptr = soa1.template begin<Particle::AttributeNames::typeId>();
+    const auto *const __restrict typeID2ptr = soa2.template begin<Particle::AttributeNames::typeId>();
 
-    __m256d virialSumXX = _mm256_setzero_pd();
-    __m256d virialSumYY = _mm256_setzero_pd();
-    __m256d virialSumZZ = _mm256_setzero_pd();
-    __m256d virialSumXY = _mm256_setzero_pd();
-    __m256d virialSumXZ = _mm256_setzero_pd();
-    __m256d virialSumYZ = _mm256_setzero_pd();
+    __m256d virialSumX = _mm256_setzero_pd();
+    __m256d virialSumY = _mm256_setzero_pd();
+    __m256d virialSumZ = _mm256_setzero_pd();
     __m256d upotSum = _mm256_setzero_pd();
 
-    for (unsigned int i = 0; i < soa1.getNumParticles(); ++i) {
-      if (ownedStatePtr1[i] == autopas::OwnershipState::dummy) {
+    for (unsigned int i = 0; i < soa1.getNumberOfParticles(); ++i) {
+      if (ownedStatePtr1[i] == OwnershipState::dummy) {
         // If the i-th particle is a dummy, skip this loop iteration.
         continue;
       }
@@ -447,15 +360,11 @@ private:
       __m256d fyacc = _mm256_setzero_pd();
       __m256d fzacc = _mm256_setzero_pd();
 
-      static_assert(
-          std::is_same_v<std::underlying_type_t<autopas::OwnershipState>,
-                         int64_t>,
-          "autopas::OwnershipStates underlying type should be int64_t!");
-      // ownedStatePtr1 contains int64_t, so we broadcast these to make an
-      // __m256i. _mm256_set1_epi64x broadcasts a 64-bit integer, we use this
-      // instruction to have 4 values!
-      __m256i ownedStateI =
-          _mm256_set1_epi64x(static_cast<int64_t>(ownedStatePtr1[i]));
+      static_assert(std::is_same_v<std::underlying_type_t<OwnershipState>, int64_t>,
+                    "OwnershipStates underlying type should be int64_t!");
+      // ownedStatePtr1 contains int64_t, so we broadcast these to make an __m256i.
+      // _mm256_set1_epi64x broadcasts a 64-bit integer, we use this instruction to have 4 values!
+      __m256i ownedStateI = _mm256_set1_epi64x(static_cast<int64_t>(ownedStatePtr1[i]));
 
       const __m256d x1 = _mm256_broadcast_sd(&x1ptr[i]);
       const __m256d y1 = _mm256_broadcast_sd(&y1ptr[i]);
@@ -463,22 +372,16 @@ private:
 
       // floor soa2 numParticles to multiple of vecLength
       unsigned int j = 0;
-      for (; j < (soa2.getNumParticles() & ~(vecLength - 1)); j += 4) {
-        SoAKernel<newton3, false>(
-            j, ownedStateI, reinterpret_cast<const int64_t *>(ownedStatePtr2),
-            x1, y1, z1, x2ptr, y2ptr, z2ptr, fx2ptr, fy2ptr, fz2ptr, typeID1ptr,
-            typeID2ptr, fxacc, fyacc, fzacc, &virialSumXX, &virialSumYY,
-            &virialSumZZ, &virialSumXY, &virialSumXZ, &virialSumYZ, &upotSum,
-            0);
+      for (; j < (soa2.getNumberOfParticles() & ~(vecLength - 1)); j += 4) {
+        SoAKernel<newton3, false>(j, ownedStateI, reinterpret_cast<const int64_t *>(ownedStatePtr2), x1, y1, z1, x2ptr,
+                                  y2ptr, z2ptr, fx2ptr, fy2ptr, fz2ptr, typeID1ptr, typeID2ptr, fxacc, fyacc, fzacc,
+                                  &virialSumX, &virialSumY, &virialSumZ, &upotSum, 0);
       }
-      const int rest = (int)(soa2.getNumParticles() & (vecLength - 1));
+      const int rest = (int)(soa2.getNumberOfParticles() & (vecLength - 1));
       if (rest > 0)
-        SoAKernel<newton3, true>(
-            j, ownedStateI, reinterpret_cast<const int64_t *>(ownedStatePtr2),
-            x1, y1, z1, x2ptr, y2ptr, z2ptr, fx2ptr, fy2ptr, fz2ptr, typeID1ptr,
-            typeID2ptr, fxacc, fyacc, fzacc, &virialSumXX, &virialSumYY,
-            &virialSumZZ, &virialSumXY, &virialSumXZ, &virialSumYZ, &upotSum,
-            rest);
+        SoAKernel<newton3, true>(j, ownedStateI, reinterpret_cast<const int64_t *>(ownedStatePtr2), x1, y1, z1, x2ptr,
+                                 y2ptr, z2ptr, fx2ptr, fy2ptr, fz2ptr, typeID1ptr, typeID2ptr, fxacc, fyacc, fzacc,
+                                 &virialSumX, &virialSumY, &virialSumZ, &upotSum, rest);
 
       // horizontally reduce fDacc to sumfD
       const __m256d hSumfxfy = _mm256_hadd_pd(fxacc, fyacc);
@@ -503,46 +406,50 @@ private:
     }
 
     if constexpr (calculateGlobals) {
-      const int threadnum = autopas::autopas_get_thread_num();
+      const int threadnum = autopas_get_thread_num();
 
-      // horizontally reduce virialSum and upot
-      const auto [hSumVirialXX, hSumVirialYY] =
-          horizontallySumRegister(virialSumXX, virialSumYY);
-      const auto [hSumVirialZZ, hSumVirialXY] =
-          horizontallySumRegister(virialSumZZ, virialSumXY);
-      const auto [hSumVirialXZ, hSumVirialYZ] =
-          horizontallySumRegister(virialSumXZ, virialSumYZ);
+      // horizontally reduce virialSumX and virialSumY
+      const __m256d hSumVirialxy = _mm256_hadd_pd(virialSumX, virialSumY);
+      const __m128d hSumVirialxyLow = _mm256_extractf128_pd(hSumVirialxy, 0);
+      const __m128d hSumVirialxyHigh = _mm256_extractf128_pd(hSumVirialxy, 1);
+      const __m128d hSumVirialxyVec = _mm_add_pd(hSumVirialxyHigh, hSumVirialxyLow);
 
-      const auto [_, hSumUpot] = horizontallySumRegister(_zero, upotSum);
+      // horizontally reduce virialSumZ and upotSum
+      const __m256d hSumVirialzUpot = _mm256_hadd_pd(virialSumZ, upotSum);
+      const __m128d hSumVirialzUpotLow = _mm256_extractf128_pd(hSumVirialzUpot, 0);
+      const __m128d hSumVirialzUpotHigh = _mm256_extractf128_pd(hSumVirialzUpot, 1);
+      const __m128d hSumVirialzUpotVec = _mm_add_pd(hSumVirialzUpotHigh, hSumVirialzUpotLow);
 
-      // we have duplicated calculations, i.e., we calculate interactions
-      // multiple times, so we have to take care that we do not add the energy
-      // multiple times!
+      // globals = {virialX, virialY, virialZ, uPot}
+      double globals[4];
+      _mm_store_pd(&globals[0], hSumVirialxyVec);
+      _mm_store_pd(&globals[2], hSumVirialzUpotVec);
+
+      // we have duplicated calculations, i.e., we calculate interactions multiple times, so we have to take care
+      // that we do not add the energy multiple times!
       double energyfactor = 1.;
       if constexpr (newton3) {
-        energyfactor *=
-            0.5; // we count the energies partly to one of the two cells!
+        energyfactor *= 0.5;  // we count the energies partly to one of the two cells!
       }
 
-      _aosThreadData[threadnum].upotSum += hSumUpot * energyfactor;
-      _aosThreadData[threadnum].virialSum[0] += hSumVirialXX * energyfactor;
-      _aosThreadData[threadnum].virialSum[1] += hSumVirialYY * energyfactor;
-      _aosThreadData[threadnum].virialSum[2] += hSumVirialZZ * energyfactor;
-      _aosThreadData[threadnum].virialSum[3] += hSumVirialXY * energyfactor;
-      _aosThreadData[threadnum].virialSum[4] += hSumVirialXZ * energyfactor;
-      _aosThreadData[threadnum].virialSum[5] += hSumVirialYZ * energyfactor;
+      _aosThreadData[threadnum].virialSum[0] += globals[0] * energyfactor;
+      _aosThreadData[threadnum].virialSum[1] += globals[1] * energyfactor;
+      _aosThreadData[threadnum].virialSum[2] += globals[2] * energyfactor;
+      _aosThreadData[threadnum].upotSum += globals[3] * energyfactor;
     }
 #endif
   }
 
+#ifdef __AVX__
   /**
    * Actual inner kernel of the SoAFunctors.
    *
    * @tparam newton3
-   * @tparam remainderIsMasked If false the full vector length is used.
-   * Otherwise the last entries are masked away depending on the argument
-   * "rest".
+   * @tparam remainderIsMasked If false the full vector length is used. Otherwise the last entries are masked away
+   * depending on the argument "rest".
    * @param j
+   * @param ownedStateI
+   * @param ownedStatePtr2
    * @param x1
    * @param y1
    * @param z1
@@ -557,91 +464,47 @@ private:
    * @param fxacc
    * @param fyacc
    * @param fzacc
-   * @param virialSumXX
-   * @param virialSumYY
-   * @param virialSumZZ
+   * @param virialSumX
+   * @param virialSumY
+   * @param virialSumZ
    * @param upotSum
    * @param rest
    */
   template <bool newton3, bool remainderIsMasked>
-  inline void
-  SoAKernel(const size_t j, const __m256i ownedStateI,
-            const int64_t *const ownedStatePtr2, const __m256d &x1,
-            const __m256d &y1, const __m256d &z1, const double *const x2ptr,
-            const double *const y2ptr, const double *const z2ptr,
-            double *const fx2ptr, double *const fy2ptr, double *const fz2ptr,
-            const size_t *const typeID1ptr, const size_t *const typeID2ptr,
-            __m256d &fxacc, __m256d &fyacc, __m256d &fzacc,
-            __m256d *virialSumXX, __m256d *virialSumYY, __m256d *virialSumZZ,
-            __m256d *virialSumXY, __m256d *virialSumXZ, __m256d *virialSumYZ,
-            __m256d *upotSum, const unsigned int rest = 0) {
-#ifdef __AVX__
+  inline void SoAKernel(const size_t j, const __m256i ownedStateI, const int64_t *const __restrict ownedStatePtr2,
+                        const __m256d &x1, const __m256d &y1, const __m256d &z1, const double *const __restrict x2ptr,
+                        const double *const __restrict y2ptr, const double *const __restrict z2ptr,
+                        double *const __restrict fx2ptr, double *const __restrict fy2ptr,
+                        double *const __restrict fz2ptr, const size_t *const typeID1ptr, const size_t *const typeID2ptr,
+                        __m256d &fxacc, __m256d &fyacc, __m256d &fzacc, __m256d *virialSumX, __m256d *virialSumY,
+                        __m256d *virialSumZ, __m256d *upotSum, const unsigned int rest = 0) {
     __m256d epsilon24s = _epsilon24;
     __m256d sigmaSquares = _sigmaSquare;
     __m256d shift6s = _shift6;
-    __m256d doesInteractMask = _ffff;
     if (useMixing) {
       // the first argument for set lands in the last bits of the register
       epsilon24s = _mm256_set_pd(
-          not remainderIsMasked or rest > 3
-              ? _PPLibrary->mixing24Epsilon(*typeID1ptr, *(typeID2ptr + 3))
-              : 0,
-          not remainderIsMasked or rest > 2
-              ? _PPLibrary->mixing24Epsilon(*typeID1ptr, *(typeID2ptr + 2))
-              : 0,
-          not remainderIsMasked or rest > 1
-              ? _PPLibrary->mixing24Epsilon(*typeID1ptr, *(typeID2ptr + 1))
-              : 0,
+          not remainderIsMasked or rest > 3 ? _PPLibrary->mixing24Epsilon(*typeID1ptr, *(typeID2ptr + 3)) : 0,
+          not remainderIsMasked or rest > 2 ? _PPLibrary->mixing24Epsilon(*typeID1ptr, *(typeID2ptr + 2)) : 0,
+          not remainderIsMasked or rest > 1 ? _PPLibrary->mixing24Epsilon(*typeID1ptr, *(typeID2ptr + 1)) : 0,
           _PPLibrary->mixing24Epsilon(*typeID1ptr, *(typeID2ptr + 0)));
       sigmaSquares = _mm256_set_pd(
-          not remainderIsMasked or rest > 3
-              ? _PPLibrary->mixingSigmaSquare(*typeID1ptr, *(typeID2ptr + 3))
-              : 0,
-          not remainderIsMasked or rest > 2
-              ? _PPLibrary->mixingSigmaSquare(*typeID1ptr, *(typeID2ptr + 2))
-              : 0,
-          not remainderIsMasked or rest > 1
-              ? _PPLibrary->mixingSigmaSquare(*typeID1ptr, *(typeID2ptr + 1))
-              : 0,
+          not remainderIsMasked or rest > 3 ? _PPLibrary->mixingSigmaSquare(*typeID1ptr, *(typeID2ptr + 3)) : 0,
+          not remainderIsMasked or rest > 2 ? _PPLibrary->mixingSigmaSquare(*typeID1ptr, *(typeID2ptr + 2)) : 0,
+          not remainderIsMasked or rest > 1 ? _PPLibrary->mixingSigmaSquare(*typeID1ptr, *(typeID2ptr + 1)) : 0,
           _PPLibrary->mixingSigmaSquare(*typeID1ptr, *(typeID2ptr + 0)));
-      const __m256d doesInteractVec =
-          _mm256_set_pd(not remainderIsMasked or rest > 3
-                            ? doesInteract(*typeID1ptr, *(typeID2ptr + 3))
-                            : 0,
-                        not remainderIsMasked or rest > 2
-                            ? doesInteract(*typeID1ptr, *(typeID2ptr + 2))
-                            : 0,
-                        not remainderIsMasked or rest > 1
-                            ? doesInteract(*typeID1ptr, *(typeID2ptr + 1))
-                            : 0,
-                        doesInteract(*typeID1ptr, *(typeID2ptr + 0)));
-      // convert entries with 1 to 1 masks
-      doesInteractMask = _mm256_cmp_pd(_zero, doesInteractVec, _CMP_GT_OS);
-
       if constexpr (applyShift) {
         shift6s = _mm256_set_pd(
-            (not remainderIsMasked or rest > 3)
-                ? _PPLibrary->mixingShift6(*typeID1ptr, *(typeID2ptr + 3))
-                : 0,
-            (not remainderIsMasked or rest > 2)
-                ? _PPLibrary->mixingShift6(*typeID1ptr, *(typeID2ptr + 2))
-                : 0,
-            (not remainderIsMasked or rest > 1)
-                ? _PPLibrary->mixingShift6(*typeID1ptr, *(typeID2ptr + 1))
-                : 0,
+            (not remainderIsMasked or rest > 3) ? _PPLibrary->mixingShift6(*typeID1ptr, *(typeID2ptr + 3)) : 0,
+            (not remainderIsMasked or rest > 2) ? _PPLibrary->mixingShift6(*typeID1ptr, *(typeID2ptr + 2)) : 0,
+            (not remainderIsMasked or rest > 1) ? _PPLibrary->mixingShift6(*typeID1ptr, *(typeID2ptr + 1)) : 0,
             _PPLibrary->mixingShift6(*typeID1ptr, *(typeID2ptr + 0)));
       }
     }
 
-    const __m256d x2 = remainderIsMasked
-                           ? _mm256_maskload_pd(&x2ptr[j], _masks[rest - 1])
-                           : _mm256_loadu_pd(&x2ptr[j]);
-    const __m256d y2 = remainderIsMasked
-                           ? _mm256_maskload_pd(&y2ptr[j], _masks[rest - 1])
-                           : _mm256_loadu_pd(&y2ptr[j]);
-    const __m256d z2 = remainderIsMasked
-                           ? _mm256_maskload_pd(&z2ptr[j], _masks[rest - 1])
-                           : _mm256_loadu_pd(&z2ptr[j]);
+    const __m256d x2 = remainderIsMasked ? _mm256_maskload_pd(&x2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&x2ptr[j]);
+    const __m256d y2 = remainderIsMasked ? _mm256_maskload_pd(&y2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&y2ptr[j]);
+    const __m256d z2 = remainderIsMasked ? _mm256_maskload_pd(&z2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&z2ptr[j]);
 
     const __m256d drx = _mm256_sub_pd(x1, x2);
     const __m256d dry = _mm256_sub_pd(y1, y2);
@@ -659,24 +522,17 @@ private:
     // dr2 <= _cutoffsquare ? 0xFFFFFFFFFFFFFFFF : 0
     const __m256d cutoffMask = _mm256_cmp_pd(dr2, _cutoffsquare, _CMP_LE_OS);
 
-    // This requires that dummy is zero (otherwise when loading using a mask the
-    // owned state will not be zero)
-    const __m256i ownedStateJ =
-        remainderIsMasked
-            ? _mm256_castpd_si256(_mm256_maskload_pd(
-                  reinterpret_cast<double const *>(&ownedStatePtr2[j]),
-                  _masks[rest - 1]))
-            : _mm256_loadu_si256(
-                  reinterpret_cast<const __m256i *>(&ownedStatePtr2[j]));
-    // This requires that dummy is the first entry in autopas::OwnershipState!
-    const __m256d dummyMask =
-        _mm256_cmp_pd(_mm256_castsi256_pd(ownedStateJ), _zero, _CMP_NEQ_UQ);
+    // This requires that dummy is zero (otherwise when loading using a mask the owned state will not be zero)
+    const __m256i ownedStateJ = remainderIsMasked
+                                    ? _mm256_castpd_si256(_mm256_maskload_pd(
+                                          reinterpret_cast<double const *>(&ownedStatePtr2[j]), _masks[rest - 1]))
+                                    : _mm256_loadu_si256(reinterpret_cast<const __m256i *>(&ownedStatePtr2[j]));
+    // This requires that dummy is the first entry in OwnershipState!
+    const __m256d dummyMask = _mm256_cmp_pd(_mm256_castsi256_pd(ownedStateJ), _zero, _CMP_NEQ_UQ);
     const __m256d cutoffDummyMask = _mm256_and_pd(cutoffMask, dummyMask);
-    const __m256d cutoffDummyInteractMask = // cutoffDummyMask;
-        _mm256_and_pd(cutoffDummyMask, doesInteractMask);
 
     // if everything is masked away return from this function.
-    if (_mm256_movemask_pd(cutoffDummyInteractMask) == 0) {
+    if (_mm256_movemask_pd(cutoffDummyMask) == 0) {
       return;
     }
 
@@ -691,11 +547,8 @@ private:
     const __m256d fac = _mm256_mul_pd(lj12m6alj12e, invdr2);
 
     const __m256d facMasked =
-        remainderIsMasked
-            ? _mm256_and_pd(
-                  fac, _mm256_and_pd(cutoffDummyInteractMask,
-                                     _mm256_castsi256_pd(_masks[rest - 1])))
-            : _mm256_and_pd(fac, cutoffDummyInteractMask);
+        remainderIsMasked ? _mm256_and_pd(fac, _mm256_and_pd(cutoffDummyMask, _mm256_castsi256_pd(_masks[rest - 1])))
+                          : _mm256_and_pd(fac, cutoffDummyMask);
 
     const __m256d fx = _mm256_mul_pd(drx, facMasked);
     const __m256d fy = _mm256_mul_pd(dry, facMasked);
@@ -707,29 +560,23 @@ private:
 
     // if newton 3 is used subtract fD from particle j
     if (newton3) {
-      const __m256d fx2 = remainderIsMasked
-                              ? _mm256_maskload_pd(&fx2ptr[j], _masks[rest - 1])
-                              : _mm256_loadu_pd(&fx2ptr[j]);
-      const __m256d fy2 = remainderIsMasked
-                              ? _mm256_maskload_pd(&fy2ptr[j], _masks[rest - 1])
-                              : _mm256_loadu_pd(&fy2ptr[j]);
-      const __m256d fz2 = remainderIsMasked
-                              ? _mm256_maskload_pd(&fz2ptr[j], _masks[rest - 1])
-                              : _mm256_loadu_pd(&fz2ptr[j]);
+      const __m256d fx2 =
+          remainderIsMasked ? _mm256_maskload_pd(&fx2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&fx2ptr[j]);
+      const __m256d fy2 =
+          remainderIsMasked ? _mm256_maskload_pd(&fy2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&fy2ptr[j]);
+      const __m256d fz2 =
+          remainderIsMasked ? _mm256_maskload_pd(&fz2ptr[j], _masks[rest - 1]) : _mm256_loadu_pd(&fz2ptr[j]);
 
       const __m256d fx2new = _mm256_sub_pd(fx2, fx);
       const __m256d fy2new = _mm256_sub_pd(fy2, fy);
       const __m256d fz2new = _mm256_sub_pd(fz2, fz);
 
-      remainderIsMasked
-          ? _mm256_maskstore_pd(&fx2ptr[j], _masks[rest - 1], fx2new)
-          : _mm256_storeu_pd(&fx2ptr[j], fx2new);
-      remainderIsMasked
-          ? _mm256_maskstore_pd(&fy2ptr[j], _masks[rest - 1], fy2new)
-          : _mm256_storeu_pd(&fy2ptr[j], fy2new);
-      remainderIsMasked
-          ? _mm256_maskstore_pd(&fz2ptr[j], _masks[rest - 1], fz2new)
-          : _mm256_storeu_pd(&fz2ptr[j], fz2new);
+      remainderIsMasked ? _mm256_maskstore_pd(&fx2ptr[j], _masks[rest - 1], fx2new)
+                        : _mm256_storeu_pd(&fx2ptr[j], fx2new);
+      remainderIsMasked ? _mm256_maskstore_pd(&fy2ptr[j], _masks[rest - 1], fy2new)
+                        : _mm256_storeu_pd(&fy2ptr[j], fy2new);
+      remainderIsMasked ? _mm256_maskstore_pd(&fz2ptr[j], _masks[rest - 1], fz2new)
+                        : _mm256_storeu_pd(&fz2ptr[j], fz2new);
     }
 
     if (calculateGlobals) {
@@ -742,32 +589,26 @@ private:
       const __m256d upot = wrapperFMA(epsilon24s, lj12m6, shift6s);
 
       const __m256d upotMasked =
-          remainderIsMasked
-              ? _mm256_and_pd(
-                    upot, _mm256_and_pd(cutoffDummyInteractMask,
-                                        _mm256_castsi256_pd(_masks[rest - 1])))
-              : _mm256_and_pd(upot, cutoffDummyInteractMask);
+          remainderIsMasked ? _mm256_and_pd(upot, _mm256_and_pd(cutoffDummyMask, _mm256_castsi256_pd(_masks[rest - 1])))
+                            : _mm256_and_pd(upot, cutoffDummyMask);
 
-      __m256d ownedMaskI = _mm256_cmp_pd(
-          _mm256_castsi256_pd(ownedStateI),
-          _mm256_castsi256_pd(_ownedStateOwnedMM256i), _CMP_EQ_UQ);
+      __m256d ownedMaskI =
+          _mm256_cmp_pd(_mm256_castsi256_pd(ownedStateI), _mm256_castsi256_pd(_ownedStateOwnedMM256i), _CMP_EQ_UQ);
       __m256d energyFactor = _mm256_blendv_pd(_zero, _one, ownedMaskI);
       if constexpr (newton3) {
-        __m256d ownedMaskJ = _mm256_cmp_pd(
-            _mm256_castsi256_pd(ownedStateJ),
-            _mm256_castsi256_pd(_ownedStateOwnedMM256i), _CMP_EQ_UQ);
-        energyFactor = _mm256_add_pd(energyFactor,
-                                     _mm256_blendv_pd(_zero, _one, ownedMaskJ));
+        __m256d ownedMaskJ =
+            _mm256_cmp_pd(_mm256_castsi256_pd(ownedStateJ), _mm256_castsi256_pd(_ownedStateOwnedMM256i), _CMP_EQ_UQ);
+        energyFactor = _mm256_add_pd(energyFactor, _mm256_blendv_pd(_zero, _one, ownedMaskJ));
       }
       *upotSum = wrapperFMA(energyFactor, upotMasked, *upotSum);
-      *virialSumXX = wrapperFMA(energyFactor, virialX, *virialSumXX);
-      *virialSumYY = wrapperFMA(energyFactor, virialY, *virialSumYY);
-      *virialSumZZ = wrapperFMA(energyFactor, virialZ, *virialSumZZ);
+      *virialSumX = wrapperFMA(energyFactor, virialX, *virialSumX);
+      *virialSumY = wrapperFMA(energyFactor, virialY, *virialSumY);
+      *virialSumZ = wrapperFMA(energyFactor, virialZ, *virialSumZ);
     }
-#endif
   }
+#endif
 
-public:
+ public:
   // clang-format off
   /**
    * @copydoc Functor::SoAFunctorVerlet(SoAView<SoAArraysType> soa, const size_t indexFirst, const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList, bool newton3)
@@ -775,13 +616,10 @@ public:
    * are no dependencies, i.e. introduce colors and specify iFrom and iTo accordingly.
    */
   // clang-format on
-  void
-  SoAFunctorVerlet(autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
-                   const std::vector<size_t, autopas::AlignedAllocator<size_t>>
-                       &neighborList,
-                   bool newton3) override {
-    if (soa.getNumParticles() == 0 or neighborList.empty())
-      return;
+  void SoAFunctorVerlet(SoAView<SoAArraysType> soa, const size_t indexFirst,
+                        const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList,
+                        bool newton3) final {
+    if (soa.getNumberOfParticles() == 0 or neighborList.empty()) return;
     if (newton3) {
       SoAFunctorVerletImpl<true>(soa, indexFirst, neighborList);
     } else {
@@ -789,57 +627,30 @@ public:
     }
   }
 
-private:
-  /**
-   *   [a0, a1, a2, a3]
-   * + [b0, b1, b2, b3]
-   * ==================
-   *       [sumA, sumB]
-   */
-  inline __m128d horizontallySumRegister(__m256d a, __m256d b) {
-    const __m256d hSumAB = _mm256_hadd_pd(a, b);
-    const __m128d hSumABLow = _mm256_extractf128_pd(hSumAB, 0);
-    const __m128d hSumABHigh = _mm256_extractf128_pd(hSumAB, 1);
-    const __m128d hSumABVec = _mm_add_pd(hSumABHigh, hSumABLow);
-    return hSumABVec;
-  };
-
+ private:
   template <bool newton3>
-  void SoAFunctorVerletImpl(
-      autopas::SoAView<SoAArraysType> soa, const size_t indexFirst,
-      const std::vector<size_t, autopas::AlignedAllocator<size_t>>
-          &neighborList) {
+  void SoAFunctorVerletImpl(SoAView<SoAArraysType> soa, const size_t indexFirst,
+                            const std::vector<size_t, autopas::AlignedAllocator<size_t>> &neighborList) {
 #ifdef __AVX__
-    const auto *const __restrict__ ownedStatePtr =
-        soa.template begin<Particle::AttributeNames::ownershipState>();
-    if (ownedStatePtr[indexFirst] == autopas::OwnershipState::dummy) {
+    const auto *const __restrict ownedStatePtr = soa.template begin<Particle::AttributeNames::ownershipState>();
+    if (ownedStatePtr[indexFirst] == OwnershipState::dummy) {
       return;
     }
 
-    const auto *const __restrict__ xptr =
-        soa.template begin<Particle::AttributeNames::posX>();
-    const auto *const __restrict__ yptr =
-        soa.template begin<Particle::AttributeNames::posY>();
-    const auto *const __restrict__ zptr =
-        soa.template begin<Particle::AttributeNames::posZ>();
+    const auto *const __restrict xptr = soa.template begin<Particle::AttributeNames::posX>();
+    const auto *const __restrict yptr = soa.template begin<Particle::AttributeNames::posY>();
+    const auto *const __restrict zptr = soa.template begin<Particle::AttributeNames::posZ>();
 
-    auto *const __restrict__ fxptr =
-        soa.template begin<Particle::AttributeNames::forceX>();
-    auto *const __restrict__ fyptr =
-        soa.template begin<Particle::AttributeNames::forceY>();
-    auto *const __restrict__ fzptr =
-        soa.template begin<Particle::AttributeNames::forceZ>();
+    auto *const __restrict fxptr = soa.template begin<Particle::AttributeNames::forceX>();
+    auto *const __restrict fyptr = soa.template begin<Particle::AttributeNames::forceY>();
+    auto *const __restrict fzptr = soa.template begin<Particle::AttributeNames::forceZ>();
 
-    const auto *const __restrict__ typeIDptr =
-        soa.template begin<Particle::AttributeNames::typeId>();
+    const auto *const __restrict typeIDptr = soa.template begin<Particle::AttributeNames::typeId>();
 
     // accumulators
-    __m256d virialSumXX = _mm256_setzero_pd();
-    __m256d virialSumYY = _mm256_setzero_pd();
-    __m256d virialSumZZ = _mm256_setzero_pd();
-    __m256d virialSumXY = _mm256_setzero_pd();
-    __m256d virialSumXZ = _mm256_setzero_pd();
-    __m256d virialSumYZ = _mm256_setzero_pd();
+    __m256d virialSumX = _mm256_setzero_pd();
+    __m256d virialSumY = _mm256_setzero_pd();
+    __m256d virialSumZ = _mm256_setzero_pd();
     __m256d upotSum = _mm256_setzero_pd();
     __m256d fxacc = _mm256_setzero_pd();
     __m256d fyacc = _mm256_setzero_pd();
@@ -850,10 +661,8 @@ private:
     const auto y1 = _mm256_broadcast_sd(&yptr[indexFirst]);
     const auto z1 = _mm256_broadcast_sd(&zptr[indexFirst]);
     // ownedStatePtr contains int64_t, so we broadcast these to make an __m256i.
-    // _mm256_set1_epi64x broadcasts a 64-bit integer, we use this instruction
-    // to have 4 values!
-    __m256i ownedStateI =
-        _mm256_set1_epi64x(static_cast<int64_t>(ownedStatePtr[indexFirst]));
+    // _mm256_set1_epi64x broadcasts a 64-bit integer, we use this instruction to have 4 values!
+    __m256i ownedStateI = _mm256_set1_epi64x(static_cast<int64_t>(ownedStatePtr[indexFirst]));
 
     alignas(64) std::array<double, vecLength> x2tmp{};
     alignas(64) std::array<double, vecLength> y2tmp{};
@@ -862,8 +671,7 @@ private:
     alignas(64) std::array<double, vecLength> fy2tmp{};
     alignas(64) std::array<double, vecLength> fz2tmp{};
     alignas(64) std::array<size_t, vecLength> typeID2tmp{};
-    alignas(64) std::array<autopas::OwnershipState, vecLength>
-        ownedStates2tmp{};
+    alignas(64) std::array<autopas::OwnershipState, vecLength> ownedStates2tmp{};
 
     // load 4 neighbors
     size_t j = 0;
@@ -879,8 +687,7 @@ private:
       //      const __m256d fx2tmp = _mm256_i64gather_pd(&fxptr[j], _vindex, 1);
       //      const __m256d fy2tmp = _mm256_i64gather_pd(&fyptr[j], _vindex, 1);
       //      const __m256d fz2tmp = _mm256_i64gather_pd(&fzptr[j], _vindex, 1);
-      //      const __m256i typeID2tmp = _mm256_i64gather_epi64(&typeIDptr[j],
-      //      _vindex, 1);
+      //      const __m256i typeID2tmp = _mm256_i64gather_epi64(&typeIDptr[j], _vindex, 1);
 
       for (size_t vecIndex = 0; vecIndex < vecLength; ++vecIndex) {
         x2tmp[vecIndex] = xptr[neighborList[j + vecIndex]];
@@ -893,13 +700,10 @@ private:
         ownedStates2tmp[vecIndex] = ownedStatePtr[neighborList[j + vecIndex]];
       }
 
-      SoAKernel<newton3, false>(
-          0, ownedStateI,
-          reinterpret_cast<const int64_t *>(ownedStates2tmp.data()), x1, y1, z1,
-          x2tmp.data(), y2tmp.data(), z2tmp.data(), fx2tmp.data(),
-          fy2tmp.data(), fz2tmp.data(), &typeIDptr[indexFirst],
-          typeID2tmp.data(), fxacc, fyacc, fzacc, &virialSumXX, &virialSumYY,
-          &virialSumZZ, &virialSumXY, &virialSumXZ, &virialSumYZ, &upotSum, 0);
+      SoAKernel<newton3, false>(0, ownedStateI, reinterpret_cast<const int64_t *>(ownedStates2tmp.data()), x1, y1, z1,
+                                x2tmp.data(), y2tmp.data(), z2tmp.data(), fx2tmp.data(), fy2tmp.data(), fz2tmp.data(),
+                                &typeIDptr[indexFirst], typeID2tmp.data(), fxacc, fyacc, fzacc, &virialSumX,
+                                &virialSumY, &virialSumZ, &upotSum, 0);
 
       if (newton3) {
         for (size_t vecIndex = 0; vecIndex < vecLength; ++vecIndex) {
@@ -916,15 +720,14 @@ private:
       // AVX2 variant:
       // create buffer for 4 interaction particles
       // and fill buffers via gathering
-      //      TODO: use masked load because there will not be enough data left
-      //      for the whole gather const __m256d x2tmp =
-      //      _mm256_i64gather_pd(&xptr[j], _vindex, 1); const __m256d y2tmp =
-      //      _mm256_i64gather_pd(&yptr[j], _vindex, 1); const __m256d z2tmp =
-      //      _mm256_i64gather_pd(&zptr[j], _vindex, 1); const __m256d fx2tmp =
-      //      _mm256_i64gather_pd(&fxptr[j], _vindex, 1); const __m256d fy2tmp =
-      //      _mm256_i64gather_pd(&fyptr[j], _vindex, 1); const __m256d fz2tmp =
-      //      _mm256_i64gather_pd(&fzptr[j], _vindex, 1); const __m256d
-      //      typeID2tmp = _mm256_i64gather_pd(&typeIDptr[j], _vindex, 1);
+      //      TODO: use masked load because there will not be enough data left for the whole gather
+      //      const __m256d x2tmp = _mm256_i64gather_pd(&xptr[j], _vindex, 1);
+      //      const __m256d y2tmp = _mm256_i64gather_pd(&yptr[j], _vindex, 1);
+      //      const __m256d z2tmp = _mm256_i64gather_pd(&zptr[j], _vindex, 1);
+      //      const __m256d fx2tmp = _mm256_i64gather_pd(&fxptr[j], _vindex, 1);
+      //      const __m256d fy2tmp = _mm256_i64gather_pd(&fyptr[j], _vindex, 1);
+      //      const __m256d fz2tmp = _mm256_i64gather_pd(&fzptr[j], _vindex, 1);
+      //      const __m256d typeID2tmp = _mm256_i64gather_pd(&typeIDptr[j], _vindex, 1);
 
       for (size_t vecIndex = 0; vecIndex < rest; ++vecIndex) {
         x2tmp[vecIndex] = xptr[neighborList[j + vecIndex]];
@@ -937,14 +740,10 @@ private:
         ownedStates2tmp[vecIndex] = ownedStatePtr[neighborList[j + vecIndex]];
       }
 
-      SoAKernel<newton3, true>(
-          0, ownedStateI,
-          reinterpret_cast<const int64_t *>(ownedStates2tmp.data()), x1, y1, z1,
-          x2tmp.data(), y2tmp.data(), z2tmp.data(), fx2tmp.data(),
-          fy2tmp.data(), fz2tmp.data(), &typeIDptr[indexFirst],
-          typeID2tmp.data(), fxacc, fyacc, fzacc, &virialSumXX, &virialSumYY,
-          &virialSumZZ, &virialSumXY, &virialSumXZ, &virialSumYZ, &upotSum,
-          rest);
+      SoAKernel<newton3, true>(0, ownedStateI, reinterpret_cast<const int64_t *>(ownedStates2tmp.data()), x1, y1, z1,
+                               x2tmp.data(), y2tmp.data(), z2tmp.data(), fx2tmp.data(), fy2tmp.data(), fz2tmp.data(),
+                               &typeIDptr[indexFirst], typeID2tmp.data(), fxacc, fyacc, fzacc, &virialSumX, &virialSumY,
+                               &virialSumZ, &upotSum, rest);
 
       if (newton3) {
         for (size_t vecIndex = 0; vecIndex < rest; ++vecIndex) {
@@ -977,52 +776,48 @@ private:
     fzptr[indexFirst] += sumfz;
 
     if constexpr (calculateGlobals) {
-      const int threadnum = autopas::autopas_get_thread_num();
+      const int threadnum = autopas_get_thread_num();
 
-      // horizontally reduce virialSum and upot
-      const auto [hSumVirialXX, hSumVirialYY] =
-          horizontallySumRegister(virialSumXX, virialSumYY);
-      const auto [hSumVirialZZ, hSumVirialXY] =
-          horizontallySumRegister(virialSumZZ, virialSumXY);
-      const auto [hSumVirialXZ, hSumVirialYZ] =
-          horizontallySumRegister(virialSumXZ, virialSumYZ);
+      // horizontally reduce virialSumX and virialSumY
+      const __m256d hSumVirialxy = _mm256_hadd_pd(virialSumX, virialSumY);
+      const __m128d hSumVirialxyLow = _mm256_extractf128_pd(hSumVirialxy, 0);
+      const __m128d hSumVirialxyHigh = _mm256_extractf128_pd(hSumVirialxy, 1);
+      const __m128d hSumVirialxyVec = _mm_add_pd(hSumVirialxyHigh, hSumVirialxyLow);
 
-      const auto [_, hSumUpot] = horizontallySumRegister(_zero, upotSum);
+      // horizontally reduce virialSumZ and upotSum
+      const __m256d hSumVirialzUpot = _mm256_hadd_pd(virialSumZ, upotSum);
+      const __m128d hSumVirialzUpotLow = _mm256_extractf128_pd(hSumVirialzUpot, 0);
+      const __m128d hSumVirialzUpotHigh = _mm256_extractf128_pd(hSumVirialzUpot, 1);
+      const __m128d hSumVirialzUpotVec = _mm_add_pd(hSumVirialzUpotHigh, hSumVirialzUpotLow);
+
+      // globals = {virialX, virialY, virialZ, uPot}
+      double globals[4];
+      _mm_store_pd(&globals[0], hSumVirialxyVec);
+      _mm_store_pd(&globals[2], hSumVirialzUpotVec);
 
       double factor = 1.;
-      // we assume newton3 to be enabled in this function call, thus we multiply
-      // by two if the value of newton3 is false, since for newton3 disabled we
-      // divide by two later on.
+      // we assume newton3 to be enabled in this function call, thus we multiply by two if the value of newton3 is
+      // false, since for newton3 disabled we divide by two later on.
       factor *= newton3 ? .5 : 1.;
-      // In case we have a non-cell-wise owned state, we have multiplied
-      // everything by two, so we divide it by 2 again.
-      _aosThreadData[threadnum].virialSum[0] += hSumVirialXX * factor;
-      _aosThreadData[threadnum].virialSum[1] += hSumVirialYY * factor;
-      _aosThreadData[threadnum].virialSum[2] += hSumVirialZZ * factor;
-      _aosThreadData[threadnum].virialSum[3] += hSumVirialXY * factor;
-      _aosThreadData[threadnum].virialSum[4] += hSumVirialXZ * factor;
-      _aosThreadData[threadnum].virialSum[5] += hSumVirialYZ * factor;
-      _aosThreadData[threadnum].upotSum += hSumUpot * factor;
+      // In case we have a non-cell-wise owned state, we have multiplied everything by two, so we divide it by 2 again.
+      _aosThreadData[threadnum].virialSum[0] += globals[0] * factor;
+      _aosThreadData[threadnum].virialSum[1] += globals[1] * factor;
+      _aosThreadData[threadnum].virialSum[2] += globals[2] * factor;
+      _aosThreadData[threadnum].upotSum += globals[3] * factor;
     }
     // interact with i with 4 neighbors
-#endif // __AVX__
+#endif  // __AVX__
   }
 
-public:
+ public:
   /**
    * @copydoc Functor::getNeededAttr()
    */
   constexpr static auto getNeededAttr() {
     return std::array<typename Particle::AttributeNames, 9>{
-        Particle::AttributeNames::id,
-        Particle::AttributeNames::posX,
-        Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ,
-        Particle::AttributeNames::forceX,
-        Particle::AttributeNames::forceY,
-        Particle::AttributeNames::forceZ,
-        Particle::AttributeNames::typeId,
-        Particle::AttributeNames::ownershipState};
+        Particle::AttributeNames::id,     Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+        Particle::AttributeNames::posZ,   Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
+        Particle::AttributeNames::forceZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
   }
 
   /**
@@ -1030,12 +825,8 @@ public:
    */
   constexpr static auto getNeededAttr(std::false_type) {
     return std::array<typename Particle::AttributeNames, 6>{
-        Particle::AttributeNames::id,
-        Particle::AttributeNames::posX,
-        Particle::AttributeNames::posY,
-        Particle::AttributeNames::posZ,
-        Particle::AttributeNames::typeId,
-        Particle::AttributeNames::ownershipState};
+        Particle::AttributeNames::id,   Particle::AttributeNames::posX,   Particle::AttributeNames::posY,
+        Particle::AttributeNames::posZ, Particle::AttributeNames::typeId, Particle::AttributeNames::ownershipState};
   }
 
   /**
@@ -1043,8 +834,7 @@ public:
    */
   constexpr static auto getComputedAttr() {
     return std::array<typename Particle::AttributeNames, 3>{
-        Particle::AttributeNames::forceX, Particle::AttributeNames::forceY,
-        Particle::AttributeNames::forceZ};
+        Particle::AttributeNames::forceX, Particle::AttributeNames::forceY, Particle::AttributeNames::forceZ};
   }
 
   /**
@@ -1069,9 +859,9 @@ public:
    * Reset the global values.
    * Will set the global values to zero to prepare for the next iteration.
    */
-  void initTraversal() override {
+  void initTraversal() final {
     _upotSum = 0.;
-    _virialSum = {0., 0., 0., 0., 0., 0.};
+    _virialSum = {0., 0., 0.};
     _postProcessed = false;
     for (size_t i = 0; i < _aosThreadData.size(); ++i) {
       _aosThreadData[i].setZero();
@@ -1082,24 +872,22 @@ public:
    * Accumulates global values, e.g. upot and virial.
    * @param newton3
    */
-  void endTraversal(bool newton3) override {
+  void endTraversal(bool newton3) final {
     if (_postProcessed) {
-      throw autopas::utils::ExceptionHandler::AutoPasException(
-          "Already postprocessed, endTraversal(bool newton3) was called twice "
-          "without calling initTraversal().");
+      throw utils::ExceptionHandler::AutoPasException(
+          "Already postprocessed, endTraversal(bool newton3) was called twice without calling initTraversal().");
     }
 
     if (calculateGlobals) {
       for (size_t i = 0; i < _aosThreadData.size(); ++i) {
         _upotSum += _aosThreadData[i].upotSum;
-        _virialSum = autopas::utils::ArrayMath::add(
-            _virialSum, _aosThreadData[i].virialSum);
+        _virialSum = utils::ArrayMath::add(_virialSum, _aosThreadData[i].virialSum);
       }
       if (not newton3) {
-        // if the newton3 optimization is disabled we have added every energy
-        // contribution twice, so we divide by 2 here.
+        // if the newton3 optimization is disabled we have added every energy contribution twice, so we divide by 2
+        // here.
         _upotSum *= 0.5;
-        _virialSum = autopas::utils::ArrayMath::mulScalar(_virialSum, 0.5);
+        _virialSum = utils::ArrayMath::mulScalar(_virialSum, 0.5);
       }
       // we have always calculated 6*upot, so we divide by 6 here!
       _upotSum /= 6.;
@@ -1113,14 +901,12 @@ public:
    */
   double getUpot() {
     if (not calculateGlobals) {
-      throw autopas::utils::ExceptionHandler::AutoPasException(
-          "Trying to get upot even though calculateGlobals is false. If you "
-          "want this functor to calculate global "
+      throw utils::ExceptionHandler::AutoPasException(
+          "Trying to get upot even though calculateGlobals is false. If you want this functor to calculate global "
           "values, please specify calculateGlobals to be true.");
     }
     if (not _postProcessed) {
-      throw autopas::utils::ExceptionHandler::AutoPasException(
-          "Cannot get upot, because endTraversal was not called.");
+      throw utils::ExceptionHandler::AutoPasException("Cannot get upot, because endTraversal was not called.");
     }
     return _upotSum;
   }
@@ -1129,18 +915,16 @@ public:
    * Get the virial
    * @return the virial
    */
-  auto getVirial() {
+  double getVirial() {
     if (not calculateGlobals) {
-      throw autopas::utils::ExceptionHandler::AutoPasException(
-          "Trying to get virial even though calculateGlobals is false. If you "
-          "want this functor to calculate global "
+      throw utils::ExceptionHandler::AutoPasException(
+          "Trying to get virial even though calculateGlobals is false. If you want this functor to calculate global "
           "values, please specify calculateGlobals to be true.");
     }
     if (not _postProcessed) {
-      throw autopas::utils::ExceptionHandler::AutoPasException(
-          "Cannot get virial, because endTraversal was not called.");
+      throw utils::ExceptionHandler::AutoPasException("Cannot get virial, because endTraversal was not called.");
     }
-    return &_virialSum;
+    return _virialSum[0] + _virialSum[1] + _virialSum[2];
   }
 
   /**
@@ -1156,9 +940,8 @@ public:
     _epsilon24 = _mm256_set1_pd(epsilon24);
     _sigmaSquare = _mm256_set1_pd(sigmaSquare);
     if constexpr (applyShift) {
-      _shift6 =
-          _mm256_set1_pd(ParticlePropertiesLibrary<double, size_t>::calcShift6(
-              epsilon24, sigmaSquare, _cutoffsquare[0]));
+      _shift6 = _mm256_set1_pd(
+          ParticlePropertiesLibrary<double, size_t>::calcShift6(epsilon24, sigmaSquare, _cutoffsquare[0]));
     } else {
       _shift6 = _mm256_setzero_pd();
     }
@@ -1167,68 +950,59 @@ public:
     _epsilon24AoS = epsilon24;
     _sigmaSquareAoS = sigmaSquare;
     if constexpr (applyShift) {
-      _shift6AoS = ParticlePropertiesLibrary<double, size_t>::calcShift6(
-          epsilon24, sigmaSquare, _cutoffsquareAoS);
+      _shift6AoS = ParticlePropertiesLibrary<double, size_t>::calcShift6(epsilon24, sigmaSquare, _cutoffsquareAoS);
     } else {
       _shift6AoS = 0.;
     }
   }
 
-private:
-  inline int doesInteract(size_t i, size_t j) const {
-    return _interactingTypes[i - 1][j - 1];
-  }
-
+ private:
+#ifdef __AVX__
   /**
-   * Wrapper function for FMA. If FMA is not supported it executes first the
-   * multiplication then the addition.
+   * Wrapper function for FMA. If FMA is not supported it executes first the multiplication then the addition.
    * @param factorA
    * @param factorB
    * @param summandC
    * @return A * B + C
    */
-  inline __m256d wrapperFMA(const __m256d &factorA, const __m256d &factorB,
-                            const __m256d &summandC) {
+  inline __m256d wrapperFMA(const __m256d &factorA, const __m256d &factorB, const __m256d &summandC) {
 #ifdef __FMA__
     return _mm256_fmadd_pd(factorA, factorB, summandC);
 #elif __AVX__
     const __m256d tmp = _mm256_mul_pd(factorA, factorB);
     return _mm256_add_pd(summandC, tmp);
 #else
-    // dummy return. If no vectorization is available this whole class is
-    // pointless anyways.
+    // dummy return. If no vectorization is available this whole class is pointless anyways.
     return __m256d();
 #endif
   }
+#endif
 
   /**
-   * This class stores internal data of each thread, make sure that this data
-   * has proper size, i.e. k*64 Bytes!
+   * This class stores internal data of each thread, make sure that this data has proper size, i.e. k*64 Bytes!
    */
   class AoSThreadData {
-  public:
-    AoSThreadData() : virialSum{0., 0., 0., 0., 0., 0.}, upotSum{0.} {}
+   public:
+    AoSThreadData() : virialSum{0., 0., 0.}, upotSum{0.} {}
     void setZero() {
-      virialSum = {0., 0., 0., 0., 0., 0.};
+      virialSum = {0., 0., 0.};
       upotSum = 0.;
     }
 
     // variables
-    std::array<double, 6> virialSum;
+    std::array<double, 3> virialSum;
     double upotSum;
 
-  private:
+   private:
     // dummy parameter to get the right size (64 bytes)
-    double __remainingTo64[(64 - 7 * sizeof(double)) / sizeof(double)];
+    double __remainingTo64[4];
   };
   // make sure of the size of AoSThreadData
-  static_assert(sizeof(AoSThreadData) % 64 == 0,
-                "AoSThreadData has wrong size");
+  static_assert(sizeof(AoSThreadData) % 64 == 0, "AoSThreadData has wrong size");
 
 #ifdef __AVX__
   const __m256d _zero{_mm256_set1_pd(0.)};
   const __m256d _one{_mm256_set1_pd(1.)};
-  const __m256d _ffff{_mm256_castsi256_pd(_mm256_set1_epi64x(-1LL))};
   const __m256i _vindex = _mm256_set_epi64x(0, 1, 3, 4);
   const __m256i _masks[3]{
       _mm256_set_epi64x(0, 0, 0, -1),
@@ -1236,8 +1010,7 @@ private:
       _mm256_set_epi64x(0, -1, -1, -1),
   };
   const __m256i _ownedStateDummyMM256i{0x0};
-  const __m256i _ownedStateOwnedMM256i{
-      _mm256_set1_epi64x(static_cast<int64_t>(autopas::OwnershipState::owned))};
+  const __m256i _ownedStateOwnedMM256i{_mm256_set1_epi64x(static_cast<int64_t>(OwnershipState::owned))};
   const __m256d _cutoffsquare{};
   __m256d _shift6 = _mm256_setzero_pd();
   __m256d _epsilon24{};
@@ -1253,7 +1026,7 @@ private:
   double _upotSum;
 
   // sum of the virial, only calculated if calculateGlobals is true
-  std::array<double, 6> _virialSum;
+  std::array<double, 3> _virialSum;
 
   // thread buffer for aos
   std::vector<AoSThreadData> _aosThreadData;
@@ -1264,9 +1037,5 @@ private:
   // number of double values that fit into a vector register.
   // MUST be power of 2 because some optimizations make this assumption
   constexpr static size_t vecLength = 4;
-
-  // Type map
-  interactingTypes_t _interactingTypes;
-
-}; // namespace autopas
-} // namespace LAMMPS_NS
+};
+}  // namespace autopas

--- a/src/USER-AUTOPAS/autopas_lj_functor_avx.h
+++ b/src/USER-AUTOPAS/autopas_lj_functor_avx.h
@@ -14,7 +14,6 @@
 #include <array>
 
 #include "autopas/molecularDynamics/ParticlePropertiesLibrary.h"
-#include "autopas/iterators/SingleCellIterator.h"
 #include "autopas/pairwiseFunctors/Functor.h"
 #include "autopas/particles/OwnershipState.h"
 #include "autopas/utils/AlignedAllocator.h"

--- a/src/USER-AUTOPAS/autopas_particle.h
+++ b/src/USER-AUTOPAS/autopas_particle.h
@@ -22,7 +22,7 @@ class MoleculeLJLammps final : public autopas::Particle {
          * @param localID Local Id of the molecule.
          * @param typeId TypeId of the molecule.
          */
-        explicit MoleculeLJLammps(std::array<floatType, 3> pos, std::array<floatType, 3> v, unsigned long moleculeId,
+        explicit MoleculeLJLammps(const std::array<floatType, 3> pos, const std::array<floatType, 3> v, unsigned long moleculeId,
                             int localID, unsigned long typeId = 0)
                 : autopas::Particle(pos, v, moleculeId), _typeId(typeId), _localId(localID) {}
 
@@ -37,15 +37,9 @@ class MoleculeLJLammps final : public autopas::Particle {
             posX,
             posY,
             posZ,
-            velocityX,
-            velocityY,
-            velocityZ,
             forceX,
             forceY,
             forceZ,
-            oldForceX,
-            oldForceY,
-            oldForceZ,
             typeId,
             ownershipState
         };
@@ -58,9 +52,9 @@ class MoleculeLJLammps final : public autopas::Particle {
          * The reason for this is the easier use of the value in calculations (See LJFunctor "energyFactor")
          */
         using SoAArraysType = typename autopas::utils::SoAType<
-                MoleculeLJLammps<floatType> *, size_t /*id*/, floatType /*x*/, floatType /*y*/, floatType /*z*/, floatType /*vx*/,
-                floatType /*vy*/, floatType /*vz*/, floatType /*fx*/, floatType /*fy*/, floatType /*fz*/, floatType /*oldFx*/,
-                floatType /*oldFy*/, floatType /*oldFz*/, size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
+                MoleculeLJLammps<floatType> *, size_t /*id*/, floatType /*x*/, floatType /*y*/, floatType /*z*/,
+                floatType /*fx*/, floatType /*fy*/, floatType /*fz*/, size_t /*typeid*/,
+                autopas::OwnershipState /*ownershipState*/>::Type;
 
         /**
          * Non-const getter for the pointer of this object.
@@ -87,24 +81,12 @@ class MoleculeLJLammps final : public autopas::Particle {
                 return getR()[1];
             } else if constexpr (attribute == AttributeNames::posZ) {
                 return getR()[2];
-            } else if constexpr (attribute == AttributeNames::velocityX) {
-                return getV()[0];
-            } else if constexpr (attribute == AttributeNames::velocityY) {
-                return getV()[1];
-            } else if constexpr (attribute == AttributeNames::velocityZ) {
-                return getV()[2];
             } else if constexpr (attribute == AttributeNames::forceX) {
                 return getF()[0];
             } else if constexpr (attribute == AttributeNames::forceY) {
                 return getF()[1];
             } else if constexpr (attribute == AttributeNames::forceZ) {
                 return getF()[2];
-            } else if constexpr (attribute == AttributeNames::oldForceX) {
-                return getOldF()[0];
-            } else if constexpr (attribute == AttributeNames::oldForceY) {
-                return getOldF()[1];
-            } else if constexpr (attribute == AttributeNames::oldForceZ) {
-                return getOldF()[2];
             } else if constexpr (attribute == AttributeNames::typeId) {
                 return getTypeId();
             } else if constexpr (attribute == AttributeNames::ownershipState) {
@@ -130,24 +112,12 @@ class MoleculeLJLammps final : public autopas::Particle {
                 _r[1] = value;
             } else if constexpr (attribute == AttributeNames::posZ) {
                 _r[2] = value;
-            } else if constexpr (attribute == AttributeNames::velocityX) {
-                _v[0] = value;
-            } else if constexpr (attribute == AttributeNames::velocityY) {
-                _v[1] = value;
-            } else if constexpr (attribute == AttributeNames::velocityZ) {
-                _v[2] = value;
             } else if constexpr (attribute == AttributeNames::forceX) {
                 _f[0] = value;
             } else if constexpr (attribute == AttributeNames::forceY) {
                 _f[1] = value;
             } else if constexpr (attribute == AttributeNames::forceZ) {
                 _f[2] = value;
-            } else if constexpr (attribute == AttributeNames::oldForceX) {
-                _oldF[0] = value;
-            } else if constexpr (attribute == AttributeNames::oldForceY) {
-                _oldF[1] = value;
-            } else if constexpr (attribute == AttributeNames::oldForceZ) {
-                _oldF[2] = value;
             } else if constexpr (attribute == AttributeNames::typeId) {
                 setTypeId(value);
             } else if constexpr (attribute == AttributeNames::ownershipState) {
@@ -156,18 +126,6 @@ class MoleculeLJLammps final : public autopas::Particle {
                 autopas::utils::ExceptionHandler::exception("MoleculeLJLammps::set() unknown attribute {}", attribute);
             }
         }
-
-        /**
-         * Get the old force.
-         * @return
-         */
-        [[nodiscard]] std::array<double, 3> getOldF() const { return _oldF; }
-
-        /**
-         * Set old force.
-         * @param oldForce
-         */
-        void setOldF(const std::array<double, 3> &oldForce) { _oldF = oldForce; }
 
         /**
          * Get TypeId.
@@ -194,11 +152,6 @@ class MoleculeLJLammps final : public autopas::Particle {
          * Particle type id.
          */
         size_t _typeId = 0;
-
-        /**
-         * Old Force of the particle experiences as 3D vector.
-         */
-        std::array<double, 3> _oldF = {0., 0., 0.};
 
         int _localId = -1;
     };

--- a/src/USER-AUTOPAS/autopas_particle.h
+++ b/src/USER-AUTOPAS/autopas_particle.h
@@ -1,37 +1,206 @@
 #pragma once
 
-#include <autopas/molecularDynamics/MoleculeLJ.h>
+#include <vector>
+
+#include "autopas/particles/Particle.h"
 
 namespace LAMMPS_NS {
 
-template<typename floatType = double>
-class MoleculeLJLammps : public autopas::MoleculeLJ<floatType> {
-public:
+/**
+ * Molecule class for the LJFunctor.
+ */
+    template <typename floatType = double>
+class MoleculeLJLammps final : public autopas::Particle {
+    public:
+        MoleculeLJLammps() = default;
 
-  /**
-   * Constructor of lennard jones molecule with initialization of typeID and localID.
-   * @param pos Position of the molecule.
-   * @param v Velocity of the molecule.
-   * @param moleculeId Global Id of the molecule.
-   * @param localId Local Id of the molecule.
-   * @param typeId TypeId of the molecule.
-   */
-  MoleculeLJLammps(std::array<floatType, 3> pos, std::array<floatType, 3> v,
-                   unsigned long moleculeId, int localId,
-                   unsigned long typeId = 0)
-      : autopas::MoleculeLJ<floatType>(pos, v, moleculeId, typeId),
-        _localId(localId) {}
+        /**
+         * Constructor of lennard jones molecule with initialization of typeID.
+         * @param pos Position of the molecule.
+         * @param v Velocitiy of the molecule.
+         * @param moleculeId Global Id of the molecule.
+         * @param localID Local Id of the molecule.
+         * @param typeId TypeId of the molecule.
+         */
+        explicit MoleculeLJLammps(std::array<floatType, 3> pos, std::array<floatType, 3> v, unsigned long moleculeId,
+                            int localID, unsigned long typeId = 0)
+                : autopas::Particle(pos, v, moleculeId), _typeId(typeId), _localId(localID) {}
 
-  [[nodiscard]] int getLocalID() const {
-    return _localId;
-  }
+        ~MoleculeLJLammps() final = default;
 
-  void setLocalID(int localId) {
-    _localId = localId;
-  }
+        /**
+         * Enums used as ids for accessing and creating a dynamically sized SoA.
+         */
+        enum AttributeNames : int {
+            ptr,
+            id,
+            posX,
+            posY,
+            posZ,
+            velocityX,
+            velocityY,
+            velocityZ,
+            forceX,
+            forceY,
+            forceZ,
+            oldForceX,
+            oldForceY,
+            oldForceZ,
+            typeId,
+            ownershipState
+        };
 
-private:
-  int _localId = -1;
-};
+        /**
+         * The type for the SoA storage.
+         *
+         * @note The attribute owned is of type float but treated as a bool.
+         * This means it shall always only take values 0.0 (=false) or 1.0 (=true).
+         * The reason for this is the easier use of the value in calculations (See LJFunctor "energyFactor")
+         */
+        using SoAArraysType = typename autopas::utils::SoAType<
+                MoleculeLJLammps<floatType> *, size_t /*id*/, floatType /*x*/, floatType /*y*/, floatType /*z*/, floatType /*vx*/,
+                floatType /*vy*/, floatType /*vz*/, floatType /*fx*/, floatType /*fy*/, floatType /*fz*/, floatType /*oldFx*/,
+                floatType /*oldFy*/, floatType /*oldFz*/, size_t /*typeid*/, autopas::OwnershipState /*ownershipState*/>::Type;
 
-}
+        /**
+         * Non-const getter for the pointer of this object.
+         * @tparam attribute Attribute name.
+         * @return this.
+         */
+        template <AttributeNames attribute, std::enable_if_t<attribute == AttributeNames::ptr, bool> = true>
+        constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() {
+            return this;
+        }
+        /**
+         * Getter, which allows access to an attribute using the corresponding attribute name (defined in AttributeNames).
+         * @tparam attribute Attribute name.
+         * @return Value of the requested attribute.
+         * @note The value of owned is return as floating point number (true = 1.0, false = 0.0).
+         */
+        template <AttributeNames attribute, std::enable_if_t<attribute != AttributeNames::ptr, bool> = true>
+        constexpr typename std::tuple_element<attribute, SoAArraysType>::type::value_type get() const {
+            if constexpr (attribute == AttributeNames::id) {
+                return getID();
+            } else if constexpr (attribute == AttributeNames::posX) {
+                return getR()[0];
+            } else if constexpr (attribute == AttributeNames::posY) {
+                return getR()[1];
+            } else if constexpr (attribute == AttributeNames::posZ) {
+                return getR()[2];
+            } else if constexpr (attribute == AttributeNames::velocityX) {
+                return getV()[0];
+            } else if constexpr (attribute == AttributeNames::velocityY) {
+                return getV()[1];
+            } else if constexpr (attribute == AttributeNames::velocityZ) {
+                return getV()[2];
+            } else if constexpr (attribute == AttributeNames::forceX) {
+                return getF()[0];
+            } else if constexpr (attribute == AttributeNames::forceY) {
+                return getF()[1];
+            } else if constexpr (attribute == AttributeNames::forceZ) {
+                return getF()[2];
+            } else if constexpr (attribute == AttributeNames::oldForceX) {
+                return getOldF()[0];
+            } else if constexpr (attribute == AttributeNames::oldForceY) {
+                return getOldF()[1];
+            } else if constexpr (attribute == AttributeNames::oldForceZ) {
+                return getOldF()[2];
+            } else if constexpr (attribute == AttributeNames::typeId) {
+                return getTypeId();
+            } else if constexpr (attribute == AttributeNames::ownershipState) {
+                return this->_ownershipState;
+            } else {
+                autopas::utils::ExceptionHandler::exception("MoleculeLJLammps::get() unknown attribute {}", attribute);
+            }
+        }
+
+        /**
+         * Setter, which allows set an attribute using the corresponding attribute name (defined in AttributeNames).
+         * @tparam attribute Attribute name.
+         * @param value New value of the requested attribute.
+         * @note The value of owned is extracted from a floating point number (true = 1.0, false = 0.0).
+         */
+        template <AttributeNames attribute>
+        constexpr void set(typename std::tuple_element<attribute, SoAArraysType>::type::value_type value) {
+            if constexpr (attribute == AttributeNames::id) {
+                setID(value);
+            } else if constexpr (attribute == AttributeNames::posX) {
+                _r[0] = value;
+            } else if constexpr (attribute == AttributeNames::posY) {
+                _r[1] = value;
+            } else if constexpr (attribute == AttributeNames::posZ) {
+                _r[2] = value;
+            } else if constexpr (attribute == AttributeNames::velocityX) {
+                _v[0] = value;
+            } else if constexpr (attribute == AttributeNames::velocityY) {
+                _v[1] = value;
+            } else if constexpr (attribute == AttributeNames::velocityZ) {
+                _v[2] = value;
+            } else if constexpr (attribute == AttributeNames::forceX) {
+                _f[0] = value;
+            } else if constexpr (attribute == AttributeNames::forceY) {
+                _f[1] = value;
+            } else if constexpr (attribute == AttributeNames::forceZ) {
+                _f[2] = value;
+            } else if constexpr (attribute == AttributeNames::oldForceX) {
+                _oldF[0] = value;
+            } else if constexpr (attribute == AttributeNames::oldForceY) {
+                _oldF[1] = value;
+            } else if constexpr (attribute == AttributeNames::oldForceZ) {
+                _oldF[2] = value;
+            } else if constexpr (attribute == AttributeNames::typeId) {
+                setTypeId(value);
+            } else if constexpr (attribute == AttributeNames::ownershipState) {
+                this->_ownershipState = value;
+            } else {
+                autopas::utils::ExceptionHandler::exception("MoleculeLJLammps::set() unknown attribute {}", attribute);
+            }
+        }
+
+        /**
+         * Get the old force.
+         * @return
+         */
+        [[nodiscard]] std::array<double, 3> getOldF() const { return _oldF; }
+
+        /**
+         * Set old force.
+         * @param oldForce
+         */
+        void setOldF(const std::array<double, 3> &oldForce) { _oldF = oldForce; }
+
+        /**
+         * Get TypeId.
+         * @return
+         */
+        [[nodiscard]] size_t getTypeId() const { return _typeId; }
+
+        /**
+         * Set the type id of the Molecule.
+         * @param typeId
+         */
+        void setTypeId(size_t typeId) { _typeId = typeId; }
+
+        [[nodiscard]] int getLocalID() const {
+            return _localId;
+        }
+
+        void setLocalID(int localId) {
+            _localId = localId;
+        }
+
+    private:
+        /**
+         * Particle type id.
+         */
+        size_t _typeId = 0;
+
+        /**
+         * Old Force of the particle experiences as 3D vector.
+         */
+        std::array<double, 3> _oldF = {0., 0., 0.};
+
+        int _localId = -1;
+    };
+
+}  // namespace LAMMPS_NS

--- a/src/USER-AUTOPAS/comm_autopas.cpp
+++ b/src/USER-AUTOPAS/comm_autopas.cpp
@@ -80,7 +80,7 @@ void CommAutoPas::reverse_comm() {
     // Using force buffer
     force_buf.resize(atom->nlocal + atom->nghost);
 #pragma omp parallel default(none)
-    for (auto iter = lmp->autopas->const_iterate<autopas::haloAndOwned>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::ownedOrHalo>(); iter.isValid(); ++iter) {
       auto idx{iter->getLocalID()};
       auto &f{iter->getF()};
       std::copy(f.begin(), f.end(), force_buf[idx].begin());

--- a/src/USER-AUTOPAS/comm_autopas.cpp
+++ b/src/USER-AUTOPAS/comm_autopas.cpp
@@ -16,7 +16,7 @@ using namespace LAMMPS_NS;
 void CommAutoPas::forward_comm(int /*dummy*/) {
   // exchange data with another proc
   // if other proc is self, just copy
-  // if comm_x_only set, exchange or copy directly to x, don't unpack
+  // (if comm_x_only set, exchange or copy directly to x, don't unpack)
 
   for (int iswap = 0; iswap < nswap; iswap++) {
     if (sendproc[iswap] != me) {
@@ -196,7 +196,7 @@ void CommAutoPas::exchange() {
          iter < leavingParticles.end();) {
       auto &p{*iter};
       auto &x{p.getR()};
-      if (x[dim] < lo || x[dim] >= hi) {
+      if (x[dim] < lo || x[dim] >= hi) { // TODO: check necessary as AutoPas already checked?
         // Particle must be sent
         if (nsend > maxsend) grow_send(nsend, 1);
         nsend += avec->pack_exchange(p, &buf_send[nsend]);
@@ -205,7 +205,7 @@ void CommAutoPas::exchange() {
         auto idx{p.getLocalID()};
         avec->copy(nlocal - 1, idx, 1);
         nlocal--;
-        iter = leavingParticles.erase(iter);
+        iter = leavingParticles.erase(iter); //TODO: somehow avoid erase()
         //////////////////
       } else {
         ++iter;

--- a/src/USER-AUTOPAS/compute_temp_autopas.cpp
+++ b/src/USER-AUTOPAS/compute_temp_autopas.cpp
@@ -25,7 +25,7 @@ double LAMMPS_NS::ComputeTempAutoPas::compute_scalar() {
   double t = 0.0;
 
 #pragma omp parallel default(none) shared(mask, rmass, mass, type) reduction(+: t)
-  for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
     auto &v{iter->getV()};
     auto idx{iter->getLocalID()};
     if (mask[idx] & groupbit) {
@@ -65,7 +65,7 @@ void LAMMPS_NS::ComputeTempAutoPas::compute_vector() {
   double massone, t[6] = {0};
 
 #pragma omp parallel default(none) shared(mask, rmass, mass, type, massone) reduction(+:t[:6])
-  for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
     auto &v{iter->getV()};
     auto idx{iter->getLocalID()};
 

--- a/src/USER-AUTOPAS/domain_autopas.cpp
+++ b/src/USER-AUTOPAS/domain_autopas.cpp
@@ -34,7 +34,7 @@ void DomainAutoPas::pbc() {
   bool flag = true;
 #pragma omp parallel default(none) shared(leavingParticles) reduction(&& : flag)
   {
-    for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x{iter->getR()};
       flag &= std::all_of(x.begin(), x.end(),
                           [](auto _) { return std::isfinite(_); });
@@ -267,7 +267,7 @@ void DomainAutoPas::lamda2x(int n) {
   }
 
 #pragma omp parallel default(none) shared(n)
-  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
 
     auto idx{iter->getLocalID()};
     if (idx < n) {
@@ -291,7 +291,7 @@ void DomainAutoPas::x2lamda(int n) {
   double delta[3];
 
 #pragma omp parallel default(none) shared(n) private(delta)
-  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
 
     auto idx{iter->getLocalID()};
     if (idx < n) {
@@ -344,7 +344,7 @@ void DomainAutoPas::reset_box() {
     min_x_0 = min_x_1 = min_x_2 = std::numeric_limits<double>::max();
 
 #pragma omp parallel default(none) reduction(min:min_x_0,min_x_1,min_x_2) reduction(max:max_x_0,max_x_1,max_x_2)
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
 
       min_x_0 = std::min(min_x_0, x[0]);

--- a/src/USER-AUTOPAS/domain_autopas.cpp
+++ b/src/USER-AUTOPAS/domain_autopas.cpp
@@ -40,7 +40,7 @@ void DomainAutoPas::pbc() {
                           [](auto _) { return std::isfinite(_); });
     }
 
-#pragma omp for
+#pragma omp for // TODO: Check if this makes sense
     for (auto iter = leavingParticles.cbegin();
          iter < leavingParticles.cend(); ++iter) {
       auto &x{iter->getR()};

--- a/src/USER-AUTOPAS/fix_addforce_autopas.cpp
+++ b/src/USER-AUTOPAS/fix_addforce_autopas.cpp
@@ -55,7 +55,7 @@ void FixAddForceAutoPas::post_force(int vflag) {
 
   if (varflag == CONSTANT) {
 #pragma omp parallel default(none) shared(region) reduction(+:foriginal[:4])
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};
@@ -107,7 +107,7 @@ void FixAddForceAutoPas::post_force(int vflag) {
     modify->addstep_compute(update->ntimestep + 1);
 
 #pragma omp parallel default(none) shared(region) reduction(+:foriginal[:3])
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};

--- a/src/USER-AUTOPAS/fix_aveforce_autopas.cpp
+++ b/src/USER-AUTOPAS/fix_aveforce_autopas.cpp
@@ -36,7 +36,7 @@ void FixAveForceAutoPas::post_force(int /*vflag*/) {
   foriginal[0] = foriginal[1] = foriginal[2] = foriginal[3] = 0.0;
 
 #pragma omp parallel default(none) shared(region) reduction(+:foriginal[:4])
-  for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
     auto &x = iter->getR();
     auto &f = iter->getF();
     auto idx{iter->getLocalID()};
@@ -75,7 +75,7 @@ void FixAveForceAutoPas::post_force(int /*vflag*/) {
   // only for active dimensions
 
 #pragma omp parallel default(none) shared(region, fave)
-  for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
     auto &x = iter->getR();
     auto &f = iter->getF();
     auto idx{iter->getLocalID()};
@@ -108,7 +108,7 @@ FixAveForceAutoPas::post_force_respa(int vflag, int ilevel, int /*iloop*/) {
     foriginal[0] = foriginal[1] = foriginal[2] = foriginal[3] = 0.0;
 
 #pragma omp parallel default(none) shared(region) reduction(+:foriginal[:4])
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};
@@ -132,7 +132,7 @@ FixAveForceAutoPas::post_force_respa(int vflag, int ilevel, int /*iloop*/) {
     fave[2] = foriginal_all[2] / ncount;
 
 #pragma omp parallel default(none) shared(region, fave)
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};

--- a/src/USER-AUTOPAS/fix_enforce2d_autopas.cpp
+++ b/src/USER-AUTOPAS/fix_enforce2d_autopas.cpp
@@ -12,7 +12,7 @@ void FixEnforce2DAutoPas::post_force(int vflag) {
   if (igroup == atom->firstgroup) nlocal = atom->nfirst;
 
 #pragma omp parallel default(none) shared(mask, nlocal)
-  for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
     auto v = iter->getV();
     auto f = iter->getF();
     auto idx{iter->getLocalID()};

--- a/src/USER-AUTOPAS/fix_indent_autopas.cpp
+++ b/src/USER-AUTOPAS/fix_indent_autopas.cpp
@@ -54,7 +54,7 @@ void FixIndentAutoPas::post_force(int vflag) {
 
 
 #pragma omp parallel default(none) shared(ctr, radius) reduction(-:indenter[:3])
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};
@@ -120,7 +120,7 @@ void FixIndentAutoPas::post_force(int vflag) {
 
 
 #pragma omp parallel default(none) shared(ctr, radius) reduction(-:indenter[:3])
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};
@@ -171,7 +171,7 @@ void FixIndentAutoPas::post_force(int vflag) {
     else plane = pvalue;
 
 #pragma omp parallel default(none) shared(plane) reduction(-:indenter[:3])
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};

--- a/src/USER-AUTOPAS/fix_nve_autopas.cpp
+++ b/src/USER-AUTOPAS/fix_nve_autopas.cpp
@@ -23,7 +23,7 @@ void LAMMPS_NS::FixNVEAutoPas::do_integrate() {
   int *mask = atom->mask;
 
 #pragma omp parallel default(none) shared(rmass, mass, type, mask)
-  for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
     auto &particle = *iter;
     auto idx{particle.getLocalID()};
     if (mask[idx] & groupbit) {

--- a/src/USER-AUTOPAS/fix_setforce_autopas.cpp
+++ b/src/USER-AUTOPAS/fix_setforce_autopas.cpp
@@ -43,7 +43,7 @@ void FixSetForceAutoPas::post_force(int vflag) {
 
   if (varflag == CONSTANT) {
 #pragma omp parallel default(none) shared(region) reduction(+:foriginal[:3])
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};
@@ -79,7 +79,7 @@ void FixSetForceAutoPas::post_force(int vflag) {
     modify->addstep_compute(update->ntimestep + 1);
 
 #pragma omp parallel default(none) shared(region) reduction(+:foriginal[:3])
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};
@@ -114,7 +114,7 @@ void FixSetForceAutoPas::post_force_respa(int vflag, int ilevel, int iloop) {
     }
 
 #pragma omp parallel default(none) shared(region)
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x = iter->getR();
       auto &f = iter->getF();
       auto idx{iter->getLocalID()};

--- a/src/USER-AUTOPAS/fix_temp_rescale_autopas.cpp
+++ b/src/USER-AUTOPAS/fix_temp_rescale_autopas.cpp
@@ -66,7 +66,7 @@ void FixTempRescaleAutoPas::end_of_step() {
     energy += (t_current - t_target) * efactor;
 
 #pragma omp parallel default(none) shared(factor)
-    for (auto iter = lmp->autopas->iterate<autopas::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto v = iter->getV();
       int idx = iter->getLocalID();
       if (atom->mask[idx] & groupbit) {

--- a/src/USER-AUTOPAS/neighbor_autopas.cpp
+++ b/src/USER-AUTOPAS/neighbor_autopas.cpp
@@ -61,7 +61,7 @@ int LAMMPS_NS::NeighborAutoPas::check_distance() {
   int flag = 0;
 
 #pragma omp parallel default(none) shared(nlocal, deltasq) private(delx, dely, delz, rsq) reduction(max: flag)
-  for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
     auto &x{iter->getR()};
     auto idx{iter->getLocalID()};
     if (idx < nlocal) {
@@ -108,7 +108,7 @@ void LAMMPS_NS::NeighborAutoPas::build(int topoflag) {
     }
 
 #pragma omp parallel default(none) shared(nlocal)
-    for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::ownedOnly>(); iter.isValid(); ++iter) {
+    for (auto iter = lmp->autopas->const_iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
       auto &x{iter->getR()};
       auto idx{iter->getLocalID()};
       if (idx < nlocal) {
@@ -168,7 +168,7 @@ void LAMMPS_NS::NeighborAutoPas::build(int topoflag) {
 int LAMMPS_NS::NeighborAutoPas::decide() {
   assert(lmp->autopas->is_initialized());
 
-  bool must_rebuild = Neighbor::decide();
-
-  return lmp->autopas->update_autopas(must_rebuild);
+  // bool must_rebuild = Neighbor::decide();
+  lmp->autopas->update_autopas();
+  return 1;
 }

--- a/src/USER-AUTOPAS/neighbor_autopas.cpp
+++ b/src/USER-AUTOPAS/neighbor_autopas.cpp
@@ -168,7 +168,7 @@ void LAMMPS_NS::NeighborAutoPas::build(int topoflag) {
 int LAMMPS_NS::NeighborAutoPas::decide() {
   assert(lmp->autopas->is_initialized());
 
-  // bool must_rebuild = Neighbor::decide();
-  lmp->autopas->update_autopas();
-  return 1;
+  bool must_rebuild = Neighbor::decide();
+  bool autopas_rebuild = lmp->autopas->update_autopas();
+  return (must_rebuild || autopas_rebuild);
 }

--- a/src/USER-AUTOPAS/verlet_autopas.cpp
+++ b/src/USER-AUTOPAS/verlet_autopas.cpp
@@ -35,7 +35,7 @@ void VerletAutoPas::run(int i) {
 
 void VerletAutoPas::force_clear() {
 #pragma omp parallel default(none)
-  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::ownedOnly>(); iter.isValid(); ++iter) {
+  for (auto iter = lmp->autopas->iterate<autopas::IteratorBehavior::owned>(); iter.isValid(); ++iter) {
     iter->setF({0, 0, 0});
   }
 }


### PR DESCRIPTION
Updates the code to be compatible with AutoPas `v2.0.0`.

- [x] API updates (mostly `IteratorBehavior` and `OwnershipType` names)
- [x] Include path updates w.r.t. `molecularDynamicsLibrary`.
- [x] AutoPas version choosable via CMake
- [x] Support multiple tuning strategies